### PR TITLE
fix: prevent form_elements JSON round-trip data loss

### DIFF
--- a/internal/client/form_definitions.go
+++ b/internal/client/form_definitions.go
@@ -48,13 +48,14 @@ type FormElementAPI struct {
 	ID          string                  `json:"id,omitempty"`
 	ElementType string                  `json:"elementType,omitempty"` // TEXT, TOGGLE, TEXTAREA, HIDDEN, PHONE, EMAIL, SELECT, DATE, SECTION, COLUMN_SET, IMAGE, DESCRIPTION
 	Config      map[string]interface{}  `json:"config,omitempty"`      // Arbitrary config based on element type
-	Key         string                  `json:"key,omitempty"`
-	Validations []FormElementValidation `json:"validations,omitempty"`
+	Key         string                  `json:"key"`
+	Validations []FormElementValidation `json:"validations"`
 }
 
 // FormElementValidation represents validation rules for a form element.
 type FormElementValidation struct {
-	ValidationType string `json:"validationType,omitempty"` // REQUIRED, MIN_LENGTH, MAX_LENGTH, REGEX, DATE, MAX_DATE, MIN_DATE, LESS_THAN_DATE, PHONE, EMAIL, DATA_SOURCE, TEXTAREA
+	ValidationType string                 `json:"validationType,omitempty"` // REQUIRED, MIN_LENGTH, MAX_LENGTH, REGEX, DATE, MAX_DATE, MIN_DATE, LESS_THAN_DATE, PHONE, EMAIL, DATA_SOURCE, TEXTAREA
+	Config         map[string]interface{} `json:"config,omitempty"`
 }
 
 // FormConditionAPI represents conditional logic that can dynamically modify the form.


### PR DESCRIPTION
## Summary
- Remove `omitempty` from `Key` and `Validations` fields in `FormElementAPI` so empty arrays (`[]`) and empty strings (`""`) are preserved during JSON re-marshaling
- Add missing `Config` field to `FormElementValidation` to preserve validation config objects like `{"config":{"min":2},"validationType":"MIN_LENGTH"}`

Closes #68

## Test plan
- [ ] Apply a `sailpoint_form_definition` with SECTION elements containing `"validations":[]` — should no longer produce "inconsistent result after apply"
- [ ] Verify form elements with `"key":""` are preserved correctly
- [ ] Verify validations with config (e.g., `MIN_LENGTH` with min value) are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)