### PR TITLE
fix: handle null authoritative_source during identity_profile import

### DIFF
--- a/internal/services/identity_profile/identity_profile_model.go
+++ b/internal/services/identity_profile/identity_profile_model.go
@@ -146,7 +146,7 @@ type identityProfileModel struct {
 	Description             types.String                  `tfsdk:"description"`
 	Owner                   *common.ObjectRefModel        `tfsdk:"owner"`
 	Priority                types.Int64                   `tfsdk:"priority"`
-	AuthoritativeSource     common.ObjectRefModel         `tfsdk:"authoritative_source"`
+	AuthoritativeSource     *common.ObjectRefModel        `tfsdk:"authoritative_source"`
 	IdentityAttributeConfig *identityAttributeConfigModel `tfsdk:"identity_attribute_config"`
 	Created                 types.String                  `tfsdk:"created"`
 	Modified                types.String                  `tfsdk:"modified"`
@@ -172,8 +172,12 @@ func (m *identityProfileModel) FromAPI(ctx context.Context, api client.IdentityP
 		diagnostics.Append(diags...)
 	}
 
-	// Map AuthoritativeSource
-	diagnostics.Append(m.AuthoritativeSource.FromAPI(ctx, api.AuthoritativeSource)...)
+	// Map AuthoritativeSource (required, but may be null during import)
+	if api.AuthoritativeSource.ID != "" {
+		var diags diag.Diagnostics
+		m.AuthoritativeSource, diags = common.NewObjectRefFromAPIPtr(ctx, api.AuthoritativeSource)
+		diagnostics.Append(diags...)
+	}
 
 	// Map IdentityAttributeConfig
 	m.IdentityAttributeConfig = &identityAttributeConfigModel{}
@@ -208,9 +212,11 @@ func (m *identityProfileModel) ToAPI(ctx context.Context) (client.IdentityProfil
 		apiRequest.Priority = m.Priority.ValueInt64()
 	}
 
-	// Map AuthoritativeSource
-	apiRequest.AuthoritativeSource, diags = m.AuthoritativeSource.ToAPI(ctx)
-	diagnostics.Append(diags...)
+	// Map AuthoritativeSource (required)
+	if m.AuthoritativeSource != nil {
+		apiRequest.AuthoritativeSource, diags = m.AuthoritativeSource.ToAPI(ctx)
+		diagnostics.Append(diags...)
+	}
 
 	// Map IdentityAttributeConfig (required)
 	if m.IdentityAttributeConfig != nil {


### PR DESCRIPTION
## Summary
- Changed `AuthoritativeSource` from value type (`common.ObjectRefModel`) to pointer (`*common.ObjectRefModel`) in the identity profile model so the Plugin Framework can reflect null values during `ImportState`
- Added nil guards in `FromAPI` and `ToAPI` matching the existing `Owner` pattern
- Fixes the "Value Conversion Error" crash when importing identity profiles via `import {}` block

Closes #74

## Test plan
- [x] `make build` — compiles successfully
- [x] `make test` — all unit tests pass
- [x] `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)