### PR TITLE
fix: surface real API errors instead of "content decoder not found"

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -55,7 +55,12 @@ func NewClient(baseURL, clientID, clientSecret string) (*Client, error) {
 			}
 			req.
 				SetHeader("Authorization", fmt.Sprintf("Bearer %s", token)).
-				SetHeader("Accept", "application/json")
+				SetHeader("Accept", "application/json").
+				// Force identity encoding so responses are never compressed with a
+				// codec Resty v3 can't decompress (e.g. brotli, zstd). Without this,
+				// 4xx responses from SailPoint surface as the misleading
+				// "resty: content decoder not found" instead of the real API error.
+				SetHeader("Accept-Encoding", "identity")
 			if req.Header.Get("Content-Type") == "" {
 				req.SetHeader("Content-Type", "application/json")
 			}


### PR DESCRIPTION
## Summary
- Force `Accept-Encoding: identity` on all SailPoint API requests so responses are never compressed with a codec Resty v3 can't decompress
- Resty v3 beta only registers `gzip` and `deflate` decompressers; Brotli-encoded error responses from SailPoint/CDN were surfacing as the misleading `resty: content decoder not found` error instead of the real 400/422 API message
- With identity encoding, error responses flow through the existing `formatXxxError` handlers which include `ResponseBody: string(resp.Bytes())`

Closes #81

## Test plan
- [x] `make build` — compiles
- [x] `make lint` — 0 issues
- [ ] Smoke test: trigger a 400 (e.g. transform with em-dash in name) and verify real API error surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)