### PR TITLE
feat: add sailpoint_segment resource and data source

### DIFF
--- a/examples/data-sources/sailpoint_segment/main.tf
+++ b/examples/data-sources/sailpoint_segment/main.tf
@@ -1,0 +1,16 @@
+# Look up an existing segment by ID
+data "sailpoint_segment" "example" {
+  id = "2c91808a7813090a017ecccc00000001"
+}
+
+output "segment_name" {
+  value = data.sailpoint_segment.example.name
+}
+
+output "segment_active" {
+  value = data.sailpoint_segment.example.active
+}
+
+output "segment_visibility_criteria" {
+  value = data.sailpoint_segment.example.visibility_criteria
+}

--- a/examples/resources/sailpoint_segment/import.sh
+++ b/examples/resources/sailpoint_segment/import.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Import an existing segment by its ID
+terraform import sailpoint_segment.austin_office "REPLACE_WITH_SEGMENT_ID"

--- a/examples/resources/sailpoint_segment/resource.tf
+++ b/examples/resources/sailpoint_segment/resource.tf
@@ -1,0 +1,58 @@
+# Simple segment — single EQUALS condition
+resource "sailpoint_segment" "austin_office" {
+  name        = "Austin Office"
+  description = "Restricts visibility to Austin-based employees"
+  active      = true
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  visibility_criteria = {
+    expression = {
+      operator  = "EQUALS"
+      attribute = "location"
+      value = {
+        type  = "STRING"
+        value = "Austin"
+      }
+    }
+  }
+}
+
+# Compound segment — AND with multiple EQUALS children
+resource "sailpoint_segment" "austin_engineering" {
+  name        = "Austin Engineering"
+  description = "Austin-based engineering team members"
+  active      = true
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  visibility_criteria = {
+    expression = {
+      operator = "AND"
+      children = [
+        {
+          operator  = "EQUALS"
+          attribute = "location"
+          value = {
+            type  = "STRING"
+            value = "Austin"
+          }
+        },
+        {
+          operator  = "EQUALS"
+          attribute = "department"
+          value = {
+            type  = "STRING"
+            value = "Engineering"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/client/segments.go
+++ b/internal/client/segments.go
@@ -1,0 +1,252 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	segmentEndpointGet    = "/v2025/segments/{id}"
+	segmentEndpointCreate = "/v2025/segments"
+	segmentEndpointPatch  = "/v2025/segments/{id}"
+	segmentEndpointDelete = "/v2025/segments/{id}"
+)
+
+// SegmentAPI represents a SailPoint Segment from the API.
+type SegmentAPI struct {
+	ID                 string                 `json:"id,omitempty"`
+	Name               string                 `json:"name"`
+	Description        *string                `json:"description,omitempty"`
+	Active             *bool                  `json:"active,omitempty"`
+	Owner              *ObjectRefAPI          `json:"owner,omitempty"`
+	VisibilityCriteria *VisibilityCriteriaAPI `json:"visibilityCriteria,omitempty"`
+	Created            *string                `json:"created,omitempty"`
+	Modified           *string                `json:"modified,omitempty"`
+}
+
+// VisibilityCriteriaAPI wraps the expression that defines segment visibility rules.
+type VisibilityCriteriaAPI struct {
+	Expression *SegmentExpressionAPI `json:"expression,omitempty"`
+}
+
+// SegmentExpressionAPI represents a node in the visibility criteria expression tree.
+// Leaf nodes use operator "EQUALS" with attribute + value; branch nodes use "AND" with children.
+type SegmentExpressionAPI struct {
+	Operator  string                 `json:"operator"`
+	Attribute *string                `json:"attribute,omitempty"`
+	Value     *SegmentValueAPI       `json:"value,omitempty"`
+	Children  []SegmentExpressionAPI `json:"children,omitempty"`
+}
+
+// SegmentValueAPI represents a typed value within an EQUALS expression.
+type SegmentValueAPI struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// segmentErrorContext provides context for error messages.
+type segmentErrorContext struct {
+	Operation    string
+	ID           string
+	Name         string
+	ResponseBody string
+}
+
+// GetSegment retrieves a specific segment by ID.
+func (c *Client) GetSegment(ctx context.Context, id string) (*SegmentAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("segment ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting segment", map[string]any{"id": id})
+
+	var segment SegmentAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&segment).
+		SetPathParam("id", id).
+		Get(segmentEndpointGet)
+
+	if err != nil {
+		return nil, c.formatSegmentError(segmentErrorContext{Operation: "get", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatSegmentError(
+			segmentErrorContext{Operation: "get", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved segment", map[string]any{
+		"id":   id,
+		"name": segment.Name,
+	})
+	return &segment, nil
+}
+
+// CreateSegment creates a new segment.
+func (c *Client) CreateSegment(ctx context.Context, segment *SegmentAPI) (*SegmentAPI, error) {
+	if segment == nil {
+		return nil, fmt.Errorf("segment cannot be nil")
+	}
+	if segment.Name == "" {
+		return nil, fmt.Errorf("segment name cannot be empty")
+	}
+
+	requestBody, _ := json.Marshal(segment)
+	tflog.Debug(ctx, "Creating segment", map[string]any{
+		"name":         segment.Name,
+		"request_body": string(requestBody),
+	})
+
+	var result SegmentAPI
+	resp, err := c.prepareRequest(ctx).
+		SetBody(segment).
+		SetResult(&result).
+		Post(segmentEndpointCreate)
+
+	if err != nil {
+		return nil, c.formatSegmentError(segmentErrorContext{Operation: "create", Name: segment.Name}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatSegmentError(
+			segmentErrorContext{Operation: "create", Name: segment.Name, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully created segment", map[string]any{
+		"id":   result.ID,
+		"name": result.Name,
+	})
+	return &result, nil
+}
+
+// PatchSegment applies a JSON Patch document to the segment and returns the updated state.
+// When patchOps is empty, it simply fetches and returns the current state.
+func (c *Client) PatchSegment(ctx context.Context, id string, patchOps []JSONPatchOperation) (*SegmentAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("segment ID cannot be empty")
+	}
+	if len(patchOps) == 0 {
+		return c.GetSegment(ctx, id)
+	}
+
+	requestBody, _ := json.Marshal(patchOps)
+	tflog.Debug(ctx, "Updating segment (PATCH)", map[string]any{
+		"id":               id,
+		"operations_count": len(patchOps),
+		"request_body":     string(requestBody),
+	})
+
+	var result SegmentAPI
+	resp, err := c.prepareRequest(ctx).
+		SetHeader("Content-Type", "application/json-patch+json").
+		SetBody(patchOps).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Patch(segmentEndpointPatch)
+
+	if err != nil {
+		return nil, c.formatSegmentError(segmentErrorContext{Operation: "update", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatSegmentError(
+			segmentErrorContext{Operation: "update", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated segment", map[string]any{
+		"id":   id,
+		"name": result.Name,
+	})
+	return &result, nil
+}
+
+// DeleteSegment deletes a segment by ID. 404 is treated as success.
+func (c *Client) DeleteSegment(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("segment ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Deleting segment", map[string]any{"id": id})
+
+	resp, err := c.prepareRequest(ctx).
+		SetPathParam("id", id).
+		Delete(segmentEndpointDelete)
+
+	if err != nil {
+		return c.formatSegmentError(segmentErrorContext{Operation: "delete", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		if resp.StatusCode() == http.StatusNotFound {
+			tflog.Debug(ctx, "Segment not found, treating as already deleted", map[string]any{"id": id})
+			return nil
+		}
+		return c.formatSegmentError(
+			segmentErrorContext{Operation: "delete", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully deleted segment", map[string]any{"id": id})
+	return nil
+}
+
+func (c *Client) formatSegmentError(errCtx segmentErrorContext, err error, statusCode int) error {
+	var baseMsg string
+	switch {
+	case errCtx.ID != "":
+		baseMsg = fmt.Sprintf("failed to %s segment '%s'", errCtx.Operation, errCtx.ID)
+	case errCtx.Name != "":
+		baseMsg = fmt.Sprintf("failed to %s segment '%s'", errCtx.Operation, errCtx.Name)
+	default:
+		baseMsg = fmt.Sprintf("failed to %s segment", errCtx.Operation)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusConflict:
+			return fmt.Errorf("%s: conflict (409)%s", baseMsg, detail)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/launcher"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/lifecycle_state"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/segment"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/source"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/transform"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/workflow"
@@ -167,6 +168,7 @@ func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.D
 		identity_profile.NewIdentityProfileDataSource,
 		launcher.NewLauncherDataSource,
 		lifecycle_state.NewLifecycleStateDataSource,
+		segment.NewSegmentDataSource,
 		source.NewSourceDataSource,
 		source.NewSourceSchemaDataSource,
 		source.NewSourceProvisioningPolicyDataSource,
@@ -183,6 +185,7 @@ func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resou
 		identity_profile.NewIdentityProfileResource,
 		launcher.NewLauncherResource,
 		lifecycle_state.NewLifecycleStateResource,
+		segment.NewSegmentResource,
 		source.NewSourceResource,
 		source.NewSourceSchemaResource,
 		source.NewSourceProvisioningPolicyResource,

--- a/internal/services/segment/segment_data_source.go
+++ b/internal/services/segment/segment_data_source.go
@@ -1,0 +1,150 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package segment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &segmentDataSource{}
+	_ datasource.DataSourceWithConfigure = &segmentDataSource{}
+)
+
+type segmentDataSource struct {
+	client *client.Client
+}
+
+// NewSegmentDataSource creates a new data source for SailPoint Segment.
+func NewSegmentDataSource() datasource.DataSource {
+	return &segmentDataSource{}
+}
+
+func (d *segmentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_segment"
+}
+
+func (d *segmentDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "segment data source")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = c
+}
+
+func (d *segmentDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Data source for SailPoint Segment.",
+		MarkdownDescription: "Data source for SailPoint Segment. Look up a segment by ID to retrieve its configuration.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The unique identifier of the segment.",
+				Required:            true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the segment.",
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description of the segment.",
+				Computed:            true,
+			},
+			"active": schema.BoolAttribute{
+				MarkdownDescription: "Whether the segment is operational.",
+				Computed:            true,
+			},
+			"owner": schema.SingleNestedAttribute{
+				MarkdownDescription: "The owner of the segment.",
+				Computed:            true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"visibility_criteria": schema.SingleNestedAttribute{
+				MarkdownDescription: "Visibility rules that determine which identities the segment applies to.",
+				Computed:            true,
+				Attributes: map[string]schema.Attribute{
+					"expression": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"operator":  schema.StringAttribute{Computed: true},
+							"attribute": schema.StringAttribute{Computed: true},
+							"value": schema.SingleNestedAttribute{
+								Computed: true,
+								Attributes: map[string]schema.Attribute{
+									"type":  schema.StringAttribute{Computed: true},
+									"value": schema.StringAttribute{Computed: true},
+								},
+							},
+							"children": schema.ListNestedAttribute{
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"operator":  schema.StringAttribute{Computed: true},
+										"attribute": schema.StringAttribute{Computed: true},
+										"value": schema.SingleNestedAttribute{
+											Computed: true,
+											Attributes: map[string]schema.Attribute{
+												"type":  schema.StringAttribute{Computed: true},
+												"value": schema.StringAttribute{Computed: true},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created": schema.StringAttribute{
+				MarkdownDescription: "The date and time the segment was created.",
+				Computed:            true,
+			},
+			"modified": schema.StringAttribute{
+				MarkdownDescription: "The date and time the segment was last modified.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *segmentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state segmentModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, "Reading segment data source", map[string]any{"id": id})
+
+	apiResp, err := d.client.GetSegment(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Segment",
+			fmt.Sprintf("Could not read SailPoint Segment %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Segment", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/services/segment/segment_model.go
+++ b/internal/services/segment/segment_model.go
@@ -1,0 +1,284 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package segment
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// segmentValueModel represents a typed value in an EQUALS expression.
+type segmentValueModel struct {
+	Type  types.String `tfsdk:"type"`
+	Value types.String `tfsdk:"value"`
+}
+
+// segmentExpressionLeafModel represents a leaf expression (max 1 additional nesting level).
+// Leaf nodes cannot have further children.
+type segmentExpressionLeafModel struct {
+	Operator  types.String       `tfsdk:"operator"`
+	Attribute types.String       `tfsdk:"attribute"`
+	Value     *segmentValueModel `tfsdk:"value"`
+}
+
+// segmentExpressionModel represents the root expression node. It may be:
+//   - a leaf (operator=EQUALS with attribute+value, no children), or
+//   - a branch (operator=AND with children, no attribute/value).
+type segmentExpressionModel struct {
+	Operator  types.String                 `tfsdk:"operator"`
+	Attribute types.String                 `tfsdk:"attribute"`
+	Value     *segmentValueModel           `tfsdk:"value"`
+	Children  []segmentExpressionLeafModel `tfsdk:"children"`
+}
+
+// visibilityCriteriaModel wraps the segment's root expression.
+type visibilityCriteriaModel struct {
+	Expression *segmentExpressionModel `tfsdk:"expression"`
+}
+
+// segmentModel represents the Terraform state for a Segment resource.
+type segmentModel struct {
+	ID                 types.String             `tfsdk:"id"`
+	Name               types.String             `tfsdk:"name"`
+	Description        types.String             `tfsdk:"description"`
+	Active             types.Bool               `tfsdk:"active"`
+	Owner              *common.ObjectRefModel   `tfsdk:"owner"`
+	VisibilityCriteria *visibilityCriteriaModel `tfsdk:"visibility_criteria"`
+	Created            types.String             `tfsdk:"created"`
+	Modified           types.String             `tfsdk:"modified"`
+}
+
+// FromAPI maps the API response into the Terraform state.
+func (m *segmentModel) FromAPI(ctx context.Context, api *client.SegmentAPI) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	m.ID = types.StringValue(api.ID)
+	m.Name = types.StringValue(api.Name)
+	m.Description = common.StringOrNull(api.Description)
+
+	if api.Active != nil {
+		m.Active = types.BoolValue(*api.Active)
+	} else {
+		m.Active = types.BoolNull()
+	}
+
+	if api.Created != nil {
+		m.Created = types.StringValue(*api.Created)
+	} else {
+		m.Created = types.StringNull()
+	}
+	if api.Modified != nil {
+		m.Modified = types.StringValue(*api.Modified)
+	} else {
+		m.Modified = types.StringNull()
+	}
+
+	if api.Owner != nil {
+		owner, diags := common.NewObjectRefFromAPIPtr(ctx, *api.Owner)
+		diagnostics.Append(diags...)
+		m.Owner = owner
+	} else {
+		m.Owner = nil
+	}
+
+	if api.VisibilityCriteria != nil {
+		m.VisibilityCriteria = visibilityCriteriaFromAPI(api.VisibilityCriteria)
+	} else {
+		m.VisibilityCriteria = nil
+	}
+
+	return diagnostics
+}
+
+// ToAPI maps the Terraform state into an API create/replace payload.
+func (m *segmentModel) ToAPI(ctx context.Context) (*client.SegmentAPI, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+
+	api := &client.SegmentAPI{
+		Name: m.Name.ValueString(),
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		desc := m.Description.ValueString()
+		api.Description = &desc
+	}
+
+	if !m.Active.IsNull() && !m.Active.IsUnknown() {
+		active := m.Active.ValueBool()
+		api.Active = &active
+	}
+
+	if m.Owner != nil {
+		owner, diags := common.NewObjectRefToAPIPtr(ctx, *m.Owner)
+		diagnostics.Append(diags...)
+		api.Owner = owner
+	}
+
+	if m.VisibilityCriteria != nil {
+		api.VisibilityCriteria = visibilityCriteriaToAPI(m.VisibilityCriteria)
+	}
+
+	return api, diagnostics
+}
+
+// ToPatchOperations compares the plan (m) against state and returns JSON Patch ops for changed fields.
+func (m *segmentModel) ToPatchOperations(ctx context.Context, state *segmentModel) ([]client.JSONPatchOperation, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	var ops []client.JSONPatchOperation
+
+	if !m.Name.Equal(state.Name) {
+		ops = append(ops, client.NewReplacePatch("/name", m.Name.ValueString()))
+	}
+
+	if !m.Description.Equal(state.Description) {
+		if !m.Description.IsNull() {
+			ops = append(ops, client.NewReplacePatch("/description", m.Description.ValueString()))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/description"))
+		}
+	}
+
+	if !m.Active.Equal(state.Active) {
+		if !m.Active.IsNull() {
+			ops = append(ops, client.NewReplacePatch("/active", m.Active.ValueBool()))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/active"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.Owner, state.Owner) {
+		if m.Owner != nil {
+			ownerAPI, diags := common.NewObjectRefToAPIPtr(ctx, *m.Owner)
+			diagnostics.Append(diags...)
+			ops = append(ops, client.NewReplacePatch("/owner", ownerAPI))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/owner"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.VisibilityCriteria, state.VisibilityCriteria) {
+		if m.VisibilityCriteria != nil {
+			ops = append(ops, client.NewReplacePatch("/visibilityCriteria", visibilityCriteriaToAPI(m.VisibilityCriteria)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/visibilityCriteria"))
+		}
+	}
+
+	return ops, diagnostics
+}
+
+// visibilityCriteriaFromAPI converts the API visibility criteria into the Terraform model.
+func visibilityCriteriaFromAPI(api *client.VisibilityCriteriaAPI) *visibilityCriteriaModel {
+	if api == nil {
+		return nil
+	}
+	vc := &visibilityCriteriaModel{}
+	if api.Expression != nil {
+		vc.Expression = expressionFromAPI(api.Expression)
+	}
+	return vc
+}
+
+// expressionFromAPI converts a root expression node into the Terraform model.
+// Children (if any) are flattened into the leaf-only model type.
+func expressionFromAPI(api *client.SegmentExpressionAPI) *segmentExpressionModel {
+	if api == nil {
+		return nil
+	}
+	expr := &segmentExpressionModel{
+		Operator:  types.StringValue(api.Operator),
+		Attribute: stringPtrToTF(api.Attribute),
+		Value:     valueFromAPI(api.Value),
+	}
+	if len(api.Children) > 0 {
+		expr.Children = make([]segmentExpressionLeafModel, 0, len(api.Children))
+		for i := range api.Children {
+			child := &api.Children[i]
+			expr.Children = append(expr.Children, segmentExpressionLeafModel{
+				Operator:  types.StringValue(child.Operator),
+				Attribute: stringPtrToTF(child.Attribute),
+				Value:     valueFromAPI(child.Value),
+			})
+		}
+	}
+	return expr
+}
+
+// valueFromAPI converts a typed value into the Terraform model.
+func valueFromAPI(api *client.SegmentValueAPI) *segmentValueModel {
+	if api == nil {
+		return nil
+	}
+	return &segmentValueModel{
+		Type:  types.StringValue(api.Type),
+		Value: types.StringValue(api.Value),
+	}
+}
+
+// visibilityCriteriaToAPI converts the Terraform visibility criteria into an API payload.
+func visibilityCriteriaToAPI(m *visibilityCriteriaModel) *client.VisibilityCriteriaAPI {
+	if m == nil {
+		return nil
+	}
+	return &client.VisibilityCriteriaAPI{
+		Expression: expressionToAPI(m.Expression),
+	}
+}
+
+// expressionToAPI converts the root expression into an API payload.
+func expressionToAPI(m *segmentExpressionModel) *client.SegmentExpressionAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.SegmentExpressionAPI{
+		Operator:  m.Operator.ValueString(),
+		Attribute: tfToStringPtr(m.Attribute),
+		Value:     valueToAPI(m.Value),
+	}
+	if len(m.Children) > 0 {
+		api.Children = make([]client.SegmentExpressionAPI, 0, len(m.Children))
+		for i := range m.Children {
+			child := &m.Children[i]
+			api.Children = append(api.Children, client.SegmentExpressionAPI{
+				Operator:  child.Operator.ValueString(),
+				Attribute: tfToStringPtr(child.Attribute),
+				Value:     valueToAPI(child.Value),
+			})
+		}
+	}
+	return api
+}
+
+// valueToAPI converts a typed value into the API payload.
+func valueToAPI(m *segmentValueModel) *client.SegmentValueAPI {
+	if m == nil {
+		return nil
+	}
+	return &client.SegmentValueAPI{
+		Type:  m.Type.ValueString(),
+		Value: m.Value.ValueString(),
+	}
+}
+
+// stringPtrToTF converts *string to types.String (nil → null).
+func stringPtrToTF(s *string) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*s)
+}
+
+// tfToStringPtr converts types.String to *string (null/unknown → nil).
+func tfToStringPtr(s types.String) *string {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	v := s.ValueString()
+	return &v
+}

--- a/internal/services/segment/segment_resource.go
+++ b/internal/services/segment/segment_resource.go
@@ -1,0 +1,310 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package segment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &segmentResource{}
+	_ resource.ResourceWithConfigure   = &segmentResource{}
+	_ resource.ResourceWithImportState = &segmentResource{}
+)
+
+type segmentResource struct {
+	client *client.Client
+}
+
+// NewSegmentResource creates a new Segment resource.
+func NewSegmentResource() resource.Resource {
+	return &segmentResource{}
+}
+
+func (r *segmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_segment"
+}
+
+func (r *segmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "segment resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+func (r *segmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Resource for SailPoint Segment.",
+		MarkdownDescription: "Resource for SailPoint Segment. Segments control visibility of access items (access profiles, roles, entitlements) by restricting which identities can see and request them based on expression criteria.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The unique identifier of the segment.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the segment.",
+				Required:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description of the segment.",
+				Optional:            true,
+			},
+			"active": schema.BoolAttribute{
+				MarkdownDescription: "Whether the segment is operational. Inactive segments do not restrict visibility.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"owner": schema.SingleNestedAttribute{
+				MarkdownDescription: "The owner of the segment.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						MarkdownDescription: "The type of the owner object. Must be `IDENTITY`.",
+						Required:            true,
+					},
+					"id": schema.StringAttribute{
+						MarkdownDescription: "The ID of the owner.",
+						Required:            true,
+					},
+					"name": schema.StringAttribute{
+						MarkdownDescription: "The name of the owner. Resolved by the server from the owner ID.",
+						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+				},
+			},
+			"visibility_criteria": schema.SingleNestedAttribute{
+				MarkdownDescription: "Visibility rules that determine which identities the segment applies to.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"expression": schema.SingleNestedAttribute{
+						MarkdownDescription: "Root expression node. Either an `EQUALS` leaf, or an `AND` branch with `EQUALS` children.",
+						Required:            true,
+						Attributes: map[string]schema.Attribute{
+							"operator": schema.StringAttribute{
+								MarkdownDescription: "Operator for this node. One of `AND`, `EQUALS`.",
+								Required:            true,
+							},
+							"attribute": schema.StringAttribute{
+								MarkdownDescription: "Identity attribute to compare. Required when `operator` is `EQUALS`.",
+								Optional:            true,
+							},
+							"value": schema.SingleNestedAttribute{
+								MarkdownDescription: "Typed value. Required when `operator` is `EQUALS`.",
+								Optional:            true,
+								Attributes: map[string]schema.Attribute{
+									"type": schema.StringAttribute{
+										MarkdownDescription: "Value type (e.g., `STRING`).",
+										Required:            true,
+									},
+									"value": schema.StringAttribute{
+										MarkdownDescription: "Value to compare against.",
+										Required:            true,
+									},
+								},
+							},
+							"children": schema.ListNestedAttribute{
+								MarkdownDescription: "Child leaf expressions. Required when `operator` is `AND`. Children cannot have further children.",
+								Optional:            true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"operator": schema.StringAttribute{
+											MarkdownDescription: "Operator for this leaf. Typically `EQUALS`.",
+											Required:            true,
+										},
+										"attribute": schema.StringAttribute{
+											MarkdownDescription: "Identity attribute to compare.",
+											Optional:            true,
+										},
+										"value": schema.SingleNestedAttribute{
+											MarkdownDescription: "Typed value.",
+											Optional:            true,
+											Attributes: map[string]schema.Attribute{
+												"type": schema.StringAttribute{
+													MarkdownDescription: "Value type (e.g., `STRING`).",
+													Required:            true,
+												},
+												"value": schema.StringAttribute{
+													MarkdownDescription: "Value to compare against.",
+													Required:            true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created": schema.StringAttribute{
+				MarkdownDescription: "The date and time the segment was created.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"modified": schema.StringAttribute{
+				MarkdownDescription: "The date and time the segment was last modified.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (r *segmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan segmentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq, diags := plan.ToAPI(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Debug(ctx, "Creating segment", map[string]any{"name": plan.Name.ValueString()})
+	apiResp, err := r.client.CreateSegment(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Creating SailPoint Segment",
+			fmt.Sprintf("Could not create SailPoint Segment %q: %s", plan.Name.ValueString(), err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Creating SailPoint Segment", "Received nil response from SailPoint API")
+		return
+	}
+
+	var state segmentModel
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "Successfully created segment", map[string]any{
+		"id":   state.ID.ValueString(),
+		"name": state.Name.ValueString(),
+	})
+}
+
+func (r *segmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state segmentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	apiResp, err := r.client.GetSegment(ctx, id)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Segment not found, removing from state", map[string]any{"id": id})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Segment",
+			fmt.Sprintf("Could not read SailPoint Segment %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Segment", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *segmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan segmentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state segmentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	ops, diags := plan.ToPatchOperations(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.PatchSegment(ctx, id, ops)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating SailPoint Segment",
+			fmt.Sprintf("Could not update SailPoint Segment %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Updating SailPoint Segment", "Received nil response from SailPoint API")
+		return
+	}
+
+	var newState segmentModel
+	resp.Diagnostics.Append(newState.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	tflog.Info(ctx, "Successfully updated segment", map[string]any{
+		"id":   newState.ID.ValueString(),
+		"name": newState.Name.ValueString(),
+	})
+}
+
+func (r *segmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state segmentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	if err := r.client.DeleteSegment(ctx, id); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting SailPoint Segment",
+			fmt.Sprintf("Could not delete SailPoint Segment %q: %s", id, err.Error()),
+		)
+		return
+	}
+	tflog.Info(ctx, "Successfully deleted segment", map[string]any{"id": id})
+}
+
+func (r *segmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Summary
- New `sailpoint_segment` resource and data source backed by `/v2025/segments`
- Full CRUD with JSON Patch update strategy, ImportState passthrough, and 404-tolerant delete
- Visibility criteria expression tree: root `EQUALS` leaf OR `AND` branch with `EQUALS` children (2-level max per API constraint)
- Owner ObjectRef (IDENTITY) with server-resolved name
- Examples for both simple and compound segments + import script
- Data source for read-only lookup by ID

Closes #80

## Files added

- `internal/client/segments.go` — CRUD methods + API types (`SegmentAPI`, `VisibilityCriteriaAPI`, `SegmentExpressionAPI`, `SegmentValueAPI`)
- `internal/services/segment/segment_model.go` — model + FromAPI/ToAPI/ToPatchOperations
- `internal/services/segment/segment_resource.go` — resource CRUD + schema + ImportState
- `internal/services/segment/segment_data_source.go` — read-only data source
- `examples/resources/sailpoint_segment/{resource.tf,import.sh}`
- `examples/data-sources/sailpoint_segment/main.tf`
- Provider registration in `internal/provider/provider.go`

## Test plan

- [x] `make build` — compiles
- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass
- [ ] Acceptance test: create simple segment with `EQUALS` expression
- [ ] Acceptance test: create compound segment with `AND` + children
- [ ] Acceptance test: update visibility criteria via PATCH
- [ ] Acceptance test: toggle `active` flag
- [ ] Acceptance test: import existing segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)