### PR TITLE
feat: add sailpoint_entitlement resource and data source (adopt-only)

### DIFF
--- a/examples/data-sources/sailpoint_entitlement/main.tf
+++ b/examples/data-sources/sailpoint_entitlement/main.tf
@@ -1,0 +1,20 @@
+# Look up an existing entitlement by ID
+data "sailpoint_entitlement" "example" {
+  id = "REPLACE_WITH_ENTITLEMENT_ID"
+}
+
+output "entitlement_name" {
+  value = data.sailpoint_entitlement.example.name
+}
+
+output "entitlement_attribute" {
+  value = data.sailpoint_entitlement.example.attribute
+}
+
+output "entitlement_value" {
+  value = data.sailpoint_entitlement.example.value
+}
+
+output "entitlement_source" {
+  value = data.sailpoint_entitlement.example.source
+}

--- a/examples/resources/sailpoint_entitlement/import.sh
+++ b/examples/resources/sailpoint_entitlement/import.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Import an existing entitlement by its ID.
+# Note: terraform destroy is a no-op for this resource — entitlements cannot be deleted via the API.
+terraform import sailpoint_entitlement.admin_group "REPLACE_WITH_ENTITLEMENT_ID"

--- a/examples/resources/sailpoint_entitlement/resource.tf
+++ b/examples/resources/sailpoint_entitlement/resource.tf
@@ -1,0 +1,20 @@
+# Adopt an entitlement and manage its metadata.
+# The entitlement must already exist in ISC — it's created by source aggregation.
+resource "sailpoint_entitlement" "admin_group" {
+  id          = "REPLACE_WITH_ENTITLEMENT_ID"
+  requestable = true
+  privileged  = true
+  description = "AD Admin group — elevated access, requires approval"
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  segments = ["REPLACE_WITH_SEGMENT_ID"]
+}
+
+# Minimal — adopt and track in state only, no metadata overrides.
+resource "sailpoint_entitlement" "readonly_group" {
+  id = "REPLACE_WITH_ENTITLEMENT_ID"
+}

--- a/internal/client/entitlements.go
+++ b/internal/client/entitlements.go
@@ -1,0 +1,159 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	entitlementEndpointGet   = "/v2025/entitlements/{id}"
+	entitlementEndpointPatch = "/v2025/entitlements/{id}"
+)
+
+// EntitlementAPI represents a SailPoint Entitlement from the API.
+// Entitlements are managed by source aggregation; no create or delete endpoint exists.
+type EntitlementAPI struct {
+	ID                     string          `json:"id"`
+	Name                   string          `json:"name"`
+	Description            *string         `json:"description,omitempty"`
+	Attribute              string          `json:"attribute"`
+	Value                  string          `json:"value"`
+	SourceSchemaObjectType string          `json:"sourceSchemaObjectType"`
+	Privileged             *bool           `json:"privileged,omitempty"`
+	CloudGoverned          *bool           `json:"cloudGoverned,omitempty"`
+	Requestable            *bool           `json:"requestable,omitempty"`
+	Owner                  *ObjectRefAPI   `json:"owner,omitempty"`
+	Source                 *ObjectRefAPI   `json:"source,omitempty"`
+	Segments               []string        `json:"segments,omitempty"`
+	ManuallyUpdatedFields  map[string]bool `json:"manuallyUpdatedFields,omitempty"`
+	Created                *string         `json:"created,omitempty"`
+	Modified               *string         `json:"modified,omitempty"`
+}
+
+type entitlementErrorContext struct {
+	Operation    string
+	ID           string
+	ResponseBody string
+}
+
+// GetEntitlement retrieves a specific entitlement by ID.
+func (c *Client) GetEntitlement(ctx context.Context, id string) (*EntitlementAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("entitlement ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting entitlement", map[string]any{"id": id})
+
+	var ent EntitlementAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&ent).
+		SetPathParam("id", id).
+		Get(entitlementEndpointGet)
+
+	if err != nil {
+		return nil, c.formatEntitlementError(entitlementErrorContext{Operation: "get", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatEntitlementError(
+			entitlementErrorContext{Operation: "get", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved entitlement", map[string]any{
+		"id":   id,
+		"name": ent.Name,
+	})
+	return &ent, nil
+}
+
+// PatchEntitlement applies a JSON Patch document to the entitlement.
+// When patchOps is empty, it fetches and returns the current state.
+func (c *Client) PatchEntitlement(ctx context.Context, id string, patchOps []JSONPatchOperation) (*EntitlementAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("entitlement ID cannot be empty")
+	}
+	if len(patchOps) == 0 {
+		return c.GetEntitlement(ctx, id)
+	}
+
+	requestBody, _ := json.Marshal(patchOps)
+	tflog.Debug(ctx, "Updating entitlement (PATCH)", map[string]any{
+		"id":               id,
+		"operations_count": len(patchOps),
+		"request_body":     string(requestBody),
+	})
+
+	var result EntitlementAPI
+	resp, err := c.prepareRequest(ctx).
+		SetHeader("Content-Type", "application/json-patch+json").
+		SetBody(patchOps).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Patch(entitlementEndpointPatch)
+
+	if err != nil {
+		return nil, c.formatEntitlementError(entitlementErrorContext{Operation: "update", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatEntitlementError(
+			entitlementErrorContext{Operation: "update", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated entitlement", map[string]any{
+		"id":   id,
+		"name": result.Name,
+	})
+	return &result, nil
+}
+
+func (c *Client) formatEntitlementError(errCtx entitlementErrorContext, err error, statusCode int) error {
+	baseMsg := fmt.Sprintf("failed to %s entitlement", errCtx.Operation)
+	if errCtx.ID != "" {
+		baseMsg = fmt.Sprintf("failed to %s entitlement '%s'", errCtx.Operation, errCtx.ID)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusConflict:
+			return fmt.Errorf("%s: conflict (409)%s", baseMsg, detail)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/entitlement"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/form_definition"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_attribute"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_profile"
@@ -162,6 +163,7 @@ func (p *sailpointProvider) Configure(ctx context.Context, req provider.Configur
 // DataSources defines the data sources implemented in the provider.
 func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		entitlement.NewEntitlementDataSource,
 		form_definition.NewFormDefinitionDataSource,
 		identity_attribute.NewIdentityAttributeDataSource,
 		identity_profile.NewIdentityProfileDataSource,
@@ -178,6 +180,7 @@ func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.D
 // Resources defines the resources implemented in the provider.
 func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		entitlement.NewEntitlementResource,
 		form_definition.NewFormDefinitionResource,
 		identity_attribute.NewIdentityAttributeResource,
 		identity_profile.NewIdentityProfileResource,

--- a/internal/services/entitlement/entitlement_data_source.go
+++ b/internal/services/entitlement/entitlement_data_source.go
@@ -1,0 +1,117 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package entitlement
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &entitlementDataSource{}
+	_ datasource.DataSourceWithConfigure = &entitlementDataSource{}
+)
+
+type entitlementDataSource struct {
+	client *client.Client
+}
+
+// NewEntitlementDataSource creates a new data source for SailPoint Entitlement.
+func NewEntitlementDataSource() datasource.DataSource {
+	return &entitlementDataSource{}
+}
+
+func (d *entitlementDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_entitlement"
+}
+
+func (d *entitlementDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "entitlement data source")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = c
+}
+
+func (d *entitlementDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Data source for SailPoint Entitlement.",
+		MarkdownDescription: "Data source for SailPoint Entitlement. Look up an entitlement by ID to retrieve its attributes.",
+		Attributes: map[string]schema.Attribute{
+			"id":                        schema.StringAttribute{Required: true, MarkdownDescription: "The unique identifier of the entitlement."},
+			"name":                      schema.StringAttribute{Computed: true},
+			"description":               schema.StringAttribute{Computed: true},
+			"attribute":                 schema.StringAttribute{Computed: true},
+			"value":                     schema.StringAttribute{Computed: true},
+			"source_schema_object_type": schema.StringAttribute{Computed: true},
+			"privileged":                schema.BoolAttribute{Computed: true},
+			"cloud_governed":            schema.BoolAttribute{Computed: true},
+			"requestable":               schema.BoolAttribute{Computed: true},
+			"owner": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"source": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"segments": schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"manually_updated_fields": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.BoolType,
+			},
+			"created":  schema.StringAttribute{Computed: true},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *entitlementDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state entitlementModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, "Reading entitlement data source", map[string]any{"id": id})
+
+	apiResp, err := d.client.GetEntitlement(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Entitlement",
+			fmt.Sprintf("Could not read entitlement %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Entitlement", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/services/entitlement/entitlement_model.go
+++ b/internal/services/entitlement/entitlement_model.go
@@ -1,0 +1,151 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package entitlement
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// entitlementModel represents the Terraform state for an Entitlement resource.
+type entitlementModel struct {
+	ID                     types.String           `tfsdk:"id"`
+	Name                   types.String           `tfsdk:"name"`
+	Description            types.String           `tfsdk:"description"`
+	Attribute              types.String           `tfsdk:"attribute"`
+	Value                  types.String           `tfsdk:"value"`
+	SourceSchemaObjectType types.String           `tfsdk:"source_schema_object_type"`
+	Privileged             types.Bool             `tfsdk:"privileged"`
+	CloudGoverned          types.Bool             `tfsdk:"cloud_governed"`
+	Requestable            types.Bool             `tfsdk:"requestable"`
+	Owner                  *common.ObjectRefModel `tfsdk:"owner"`
+	Source                 *common.ObjectRefModel `tfsdk:"source"`
+	Segments               types.Set              `tfsdk:"segments"`
+	ManuallyUpdatedFields  types.Map              `tfsdk:"manually_updated_fields"`
+	Created                types.String           `tfsdk:"created"`
+	Modified               types.String           `tfsdk:"modified"`
+}
+
+// FromAPI maps the API response into the Terraform state.
+func (m *entitlementModel) FromAPI(ctx context.Context, api *client.EntitlementAPI) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	m.ID = types.StringValue(api.ID)
+	m.Name = types.StringValue(api.Name)
+	m.Description = common.StringOrNull(api.Description)
+	m.Attribute = types.StringValue(api.Attribute)
+	m.Value = types.StringValue(api.Value)
+	m.SourceSchemaObjectType = types.StringValue(api.SourceSchemaObjectType)
+
+	m.Privileged = boolPtrToTF(api.Privileged)
+	m.CloudGoverned = boolPtrToTF(api.CloudGoverned)
+	m.Requestable = boolPtrToTF(api.Requestable)
+
+	if api.Created != nil {
+		m.Created = types.StringValue(*api.Created)
+	} else {
+		m.Created = types.StringNull()
+	}
+	if api.Modified != nil {
+		m.Modified = types.StringValue(*api.Modified)
+	} else {
+		m.Modified = types.StringNull()
+	}
+
+	if api.Owner != nil {
+		owner, diags := common.NewObjectRefFromAPIPtr(ctx, *api.Owner)
+		diagnostics.Append(diags...)
+		m.Owner = owner
+	} else {
+		m.Owner = nil
+	}
+
+	if api.Source != nil {
+		source, diags := common.NewObjectRefFromAPIPtr(ctx, *api.Source)
+		diagnostics.Append(diags...)
+		m.Source = source
+	} else {
+		m.Source = nil
+	}
+
+	if api.Segments != nil {
+		segs, diags := types.SetValueFrom(ctx, types.StringType, api.Segments)
+		diagnostics.Append(diags...)
+		m.Segments = segs
+	} else {
+		m.Segments = types.SetNull(types.StringType)
+	}
+
+	if api.ManuallyUpdatedFields != nil {
+		muf, diags := types.MapValueFrom(ctx, types.BoolType, api.ManuallyUpdatedFields)
+		diagnostics.Append(diags...)
+		m.ManuallyUpdatedFields = muf
+	} else {
+		m.ManuallyUpdatedFields = types.MapNull(types.BoolType)
+	}
+
+	return diagnostics
+}
+
+// ToPatchOperations compares the plan (m) against state and returns JSON Patch ops for changed fields.
+// Only patchable fields are considered: name, description, requestable, privileged, owner, segments.
+func (m *entitlementModel) ToPatchOperations(ctx context.Context, state *entitlementModel) ([]client.JSONPatchOperation, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	var ops []client.JSONPatchOperation
+
+	if !m.Name.Equal(state.Name) && !m.Name.IsNull() && !m.Name.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/name", m.Name.ValueString()))
+	}
+
+	if !m.Description.Equal(state.Description) {
+		if !m.Description.IsNull() && !m.Description.IsUnknown() {
+			ops = append(ops, client.NewReplacePatch("/description", m.Description.ValueString()))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/description"))
+		}
+	}
+
+	if !m.Requestable.Equal(state.Requestable) && !m.Requestable.IsNull() && !m.Requestable.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/requestable", m.Requestable.ValueBool()))
+	}
+
+	if !m.Privileged.Equal(state.Privileged) && !m.Privileged.IsNull() && !m.Privileged.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/privileged", m.Privileged.ValueBool()))
+	}
+
+	if !reflect.DeepEqual(m.Owner, state.Owner) {
+		if m.Owner != nil {
+			ownerAPI, diags := common.NewObjectRefToAPIPtr(ctx, *m.Owner)
+			diagnostics.Append(diags...)
+			ops = append(ops, client.NewReplacePatch("/owner", ownerAPI))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/owner"))
+		}
+	}
+
+	if !m.Segments.Equal(state.Segments) {
+		if !m.Segments.IsNull() && !m.Segments.IsUnknown() {
+			var segs []string
+			diagnostics.Append(m.Segments.ElementsAs(ctx, &segs, false)...)
+			ops = append(ops, client.NewReplacePatch("/segments", segs))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/segments"))
+		}
+	}
+
+	return ops, diagnostics
+}
+
+// boolPtrToTF converts *bool to types.Bool (nil → null).
+func boolPtrToTF(b *bool) types.Bool {
+	if b == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*b)
+}

--- a/internal/services/entitlement/entitlement_resource.go
+++ b/internal/services/entitlement/entitlement_resource.go
@@ -1,0 +1,321 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package entitlement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &entitlementResource{}
+	_ resource.ResourceWithConfigure   = &entitlementResource{}
+	_ resource.ResourceWithImportState = &entitlementResource{}
+)
+
+type entitlementResource struct {
+	client *client.Client
+}
+
+// NewEntitlementResource creates a new Entitlement resource with adopt-only lifecycle.
+func NewEntitlementResource() resource.Resource {
+	return &entitlementResource{}
+}
+
+func (r *entitlementResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_entitlement"
+}
+
+func (r *entitlementResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "entitlement resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+func (r *entitlementResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Adopts an existing SailPoint Entitlement and manages its patchable metadata.",
+		MarkdownDescription: "Adopts an existing SailPoint Entitlement and manages its patchable metadata." +
+			" Entitlements cannot be created or deleted via the API — they are managed by source aggregation." +
+			" This resource uses an adopt-only lifecycle: Create reads the existing entitlement, Update patches metadata," +
+			" and Delete is a no-op that only removes the resource from Terraform state.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The unique identifier of an existing entitlement.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the entitlement. Patchable; overrides the source-aggregated name when set.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description of the entitlement. Patchable.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"attribute": schema.StringAttribute{
+				MarkdownDescription: "Source attribute name (e.g., `memberOf`). Read-only from aggregation.",
+				Computed:            true,
+			},
+			"value": schema.StringAttribute{
+				MarkdownDescription: "Source attribute value (e.g., a group DN). Read-only from aggregation.",
+				Computed:            true,
+			},
+			"source_schema_object_type": schema.StringAttribute{
+				MarkdownDescription: "Type of the entitlement in the source schema (e.g., `group`). Read-only.",
+				Computed:            true,
+			},
+			"privileged": schema.BoolAttribute{
+				MarkdownDescription: "Whether the entitlement grants elevated access. Patchable.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"cloud_governed": schema.BoolAttribute{
+				MarkdownDescription: "Whether the entitlement is cloud-governed. Read-only.",
+				Computed:            true,
+			},
+			"requestable": schema.BoolAttribute{
+				MarkdownDescription: "Whether users can request this entitlement directly. Patchable.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"owner": schema.SingleNestedAttribute{
+				MarkdownDescription: "The owner of the entitlement. Patchable.",
+				Optional:            true,
+				Computed:            true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						MarkdownDescription: "Owner type. Must be `IDENTITY`.",
+						Required:            true,
+					},
+					"id": schema.StringAttribute{
+						MarkdownDescription: "Identity ID of the owner.",
+						Required:            true,
+					},
+					"name": schema.StringAttribute{
+						MarkdownDescription: "Name of the owner identity. Server-resolved.",
+						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+				},
+			},
+			"source": schema.SingleNestedAttribute{
+				MarkdownDescription: "Source the entitlement was aggregated from. Read-only.",
+				Computed:            true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"segments": schema.SetAttribute{
+				MarkdownDescription: "Segment UUIDs the entitlement is assigned to. Patchable.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"manually_updated_fields": schema.MapAttribute{
+				MarkdownDescription: "Tracks which fields were manually overridden (protected from aggregation overwrites). Read-only.",
+				Computed:            true,
+				ElementType:         types.BoolType,
+			},
+			"created": schema.StringAttribute{
+				MarkdownDescription: "When the entitlement was first aggregated.",
+				Computed:            true,
+			},
+			"modified": schema.StringAttribute{
+				MarkdownDescription: "When the entitlement was last modified.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+// Create adopts an existing entitlement by ID. The entitlement must already exist in ISC —
+// entitlements are managed via source aggregation, not via Terraform.
+func (r *entitlementResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan entitlementModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := plan.ID.ValueString()
+	tflog.Debug(ctx, "Adopting entitlement", map[string]any{"id": id})
+
+	existing, err := r.client.GetEntitlement(ctx, id)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			resp.Diagnostics.AddError(
+				"Entitlement not found",
+				fmt.Sprintf("Entitlement %q does not exist in SailPoint ISC. Entitlements are created through source aggregation, not via Terraform.", id),
+			)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error adopting SailPoint Entitlement",
+			fmt.Sprintf("Could not read entitlement %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if existing == nil {
+		resp.Diagnostics.AddError("Error adopting SailPoint Entitlement", "Received nil response from SailPoint API")
+		return
+	}
+
+	// Populate a baseline state from the existing entitlement so we can diff the plan against it.
+	var current entitlementModel
+	resp.Diagnostics.Append(current.FromAPI(ctx, existing)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Diff plan vs current: any patchable fields the user set that differ from the current API
+	// state are applied in a single PATCH.
+	ops, diags := plan.ToPatchOperations(ctx, &current)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	final := existing
+	if len(ops) > 0 {
+		updated, err := r.client.PatchEntitlement(ctx, id, ops)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error applying initial patches to adopted Entitlement",
+				fmt.Sprintf("Could not patch entitlement %q: %s", id, err.Error()),
+			)
+			return
+		}
+		if updated != nil {
+			final = updated
+		}
+	}
+
+	var state entitlementModel
+	resp.Diagnostics.Append(state.FromAPI(ctx, final)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "Successfully adopted entitlement", map[string]any{
+		"id":      state.ID.ValueString(),
+		"name":    state.Name.ValueString(),
+		"patches": len(ops),
+	})
+}
+
+func (r *entitlementResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state entitlementModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	apiResp, err := r.client.GetEntitlement(ctx, id)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Entitlement not found, removing from state", map[string]any{"id": id})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Entitlement",
+			fmt.Sprintf("Could not read entitlement %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Entitlement", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *entitlementResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan entitlementModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state entitlementModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	ops, diags := plan.ToPatchOperations(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.PatchEntitlement(ctx, id, ops)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating SailPoint Entitlement",
+			fmt.Sprintf("Could not update entitlement %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Updating SailPoint Entitlement", "Received nil response from SailPoint API")
+		return
+	}
+
+	var newState entitlementModel
+	resp.Diagnostics.Append(newState.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	tflog.Info(ctx, "Successfully updated entitlement", map[string]any{
+		"id":      newState.ID.ValueString(),
+		"patches": len(ops),
+	})
+}
+
+// Delete is a no-op for entitlements — they are managed by source aggregation
+// and cannot be removed via the API. Terraform state tracking is dropped, but
+// the entitlement persists in ISC.
+func (r *entitlementResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Intentional no-op.
+	resp.Diagnostics.AddWarning(
+		"Entitlement not deleted from SailPoint ISC",
+		"Entitlements are managed by source aggregation and cannot be deleted via the API. "+
+			"The resource has been removed from Terraform state, but the entitlement still exists in ISC.",
+	)
+}
+
+func (r *entitlementResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Summary
- New `sailpoint_entitlement` resource with **adopt-only** lifecycle (no POST/DELETE at the API; aggregation-managed)
- Backed by `/v2025/entitlements/{id}` with JSON Patch updates
- Resource `id` is `Required` (user supplies existing entitlement UUID)
- Create = GET then optionally PATCH differences; Delete = no-op with a warning diagnostic
- Read handles 404 by removing from state
- Patchable fields: `name`, `description`, `requestable`, `privileged`, `owner`, `segments`
- Read-only fields: `attribute`, `value`, `source_schema_object_type`, `cloud_governed`, `source`, `manually_updated_fields`, `created`, `modified`
- Data source for read-only lookup by ID

Closes #79

## Files added

- `internal/client/entitlements.go` — GET/PATCH + API type + error formatter
- `internal/services/entitlement/entitlement_model.go` — model + FromAPI/ToPatchOperations (no ToAPI — no create)
- `internal/services/entitlement/entitlement_resource.go` — adopt-only CRUD + schema + ImportState
- `internal/services/entitlement/entitlement_data_source.go` — read-only data source
- `examples/resources/sailpoint_entitlement/{resource.tf,import.sh}`
- `examples/data-sources/sailpoint_entitlement/main.tf`
- Provider registration

## Test plan

- [x] `make build` — compiles
- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass
- [ ] Acceptance test: adopt existing entitlement → state matches API
- [ ] Acceptance test: PATCH requestable/privileged/owner
- [ ] Acceptance test: destroy is a no-op (entitlement still present in ISC)
- [ ] Acceptance test: non-existent ID on create → clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)