### PR TITLE
feat: add sailpoint_access_profile resource and data source

### DIFF
--- a/examples/data-sources/sailpoint_access_profile/main.tf
+++ b/examples/data-sources/sailpoint_access_profile/main.tf
@@ -1,0 +1,12 @@
+# Look up an existing access profile by ID
+data "sailpoint_access_profile" "example" {
+  id = "REPLACE_WITH_ACCESS_PROFILE_ID"
+}
+
+output "access_profile_name" {
+  value = data.sailpoint_access_profile.example.name
+}
+
+output "access_profile_entitlements" {
+  value = data.sailpoint_access_profile.example.entitlements
+}

--- a/examples/resources/sailpoint_access_profile/import.sh
+++ b/examples/resources/sailpoint_access_profile/import.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Import an existing access profile by its ID
+terraform import sailpoint_access_profile.full "REPLACE_WITH_ACCESS_PROFILE_ID"

--- a/examples/resources/sailpoint_access_profile/resource.tf
+++ b/examples/resources/sailpoint_access_profile/resource.tf
@@ -1,0 +1,48 @@
+# Minimal access profile
+resource "sailpoint_access_profile" "basic" {
+  name = "DB Read Access"
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  source = {
+    type = "SOURCE"
+    id   = "REPLACE_WITH_SOURCE_ID"
+  }
+}
+
+# Full configuration
+resource "sailpoint_access_profile" "full" {
+  name        = "Payroll Admin Access"
+  description = "Full access to payroll system administration"
+  enabled     = true
+  requestable = true
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  source = {
+    type = "SOURCE"
+    id   = "REPLACE_WITH_SOURCE_ID"
+  }
+
+  entitlements = [
+    { type = "ENTITLEMENT", id = "REPLACE_WITH_ENTITLEMENT_ID_1" },
+    { type = "ENTITLEMENT", id = "REPLACE_WITH_ENTITLEMENT_ID_2" },
+  ]
+
+  access_request_config = {
+    comments_required        = true
+    denial_comments_required = true
+    approval_schemes = [
+      { approver_type = "MANAGER" },
+      { approver_type = "GOVERNANCE_GROUP", approver_id = "REPLACE_WITH_GOVERNANCE_GROUP_ID" },
+    ]
+  }
+
+  segments = ["REPLACE_WITH_SEGMENT_ID"]
+}

--- a/internal/client/access_profiles.go
+++ b/internal/client/access_profiles.go
@@ -1,0 +1,255 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	accessProfileEndpointGet    = "/v2025/access-profiles/{id}"
+	accessProfileEndpointCreate = "/v2025/access-profiles"
+	accessProfileEndpointPatch  = "/v2025/access-profiles/{id}"
+	accessProfileEndpointDelete = "/v2025/access-profiles/{id}"
+)
+
+// AccessProfileAPI represents a SailPoint Access Profile from the API.
+type AccessProfileAPI struct {
+	ID                   string                   `json:"id,omitempty"`
+	Name                 string                   `json:"name"`
+	Description          *string                  `json:"description,omitempty"`
+	Enabled              *bool                    `json:"enabled,omitempty"`
+	Requestable          *bool                    `json:"requestable,omitempty"`
+	Owner                ObjectRefAPI             `json:"owner"`
+	Source               ObjectRefAPI             `json:"source"`
+	Entitlements         []ObjectRefAPI           `json:"entitlements,omitempty"`
+	Segments             []string                 `json:"segments,omitempty"`
+	AdditionalOwners     []ObjectRefAPI           `json:"additionalOwners,omitempty"`
+	AccessRequestConfig  *RequestabilityAPI       `json:"accessRequestConfig,omitempty"`
+	RevokeRequestConfig  *RevocabilityAPI         `json:"revokeRequestConfig,omitempty"`
+	ProvisioningCriteria *ProvisioningCriteriaAPI `json:"provisioningCriteria,omitempty"`
+	Created              *string                  `json:"created,omitempty"`
+	Modified             *string                  `json:"modified,omitempty"`
+}
+
+type RequestabilityAPI struct {
+	CommentsRequired           *bool               `json:"commentsRequired,omitempty"`
+	DenialCommentsRequired     *bool               `json:"denialCommentsRequired,omitempty"`
+	ReauthorizationRequired    *bool               `json:"reauthorizationRequired,omitempty"`
+	RequireEndDate             *bool               `json:"requireEndDate,omitempty"`
+	MaxPermittedAccessDuration *AccessDurationAPI  `json:"maxPermittedAccessDuration,omitempty"`
+	ApprovalSchemes            []ApprovalSchemeAPI `json:"approvalSchemes,omitempty"`
+}
+
+type RevocabilityAPI struct {
+	ApprovalSchemes []ApprovalSchemeAPI `json:"approvalSchemes,omitempty"`
+}
+
+type AccessDurationAPI struct {
+	Value    *int64  `json:"value,omitempty"`
+	TimeUnit *string `json:"timeUnit,omitempty"`
+}
+
+type ApprovalSchemeAPI struct {
+	ApproverType string  `json:"approverType"`
+	ApproverID   *string `json:"approverId,omitempty"`
+}
+
+// ProvisioningCriteriaAPI is a recursive tree. Max 3 levels per SailPoint constraints.
+type ProvisioningCriteriaAPI struct {
+	Operation string                    `json:"operation,omitempty"`
+	Attribute *string                   `json:"attribute,omitempty"`
+	Value     *string                   `json:"value,omitempty"`
+	Children  []ProvisioningCriteriaAPI `json:"children,omitempty"`
+}
+
+type accessProfileErrorContext struct {
+	Operation    string
+	ID           string
+	Name         string
+	ResponseBody string
+}
+
+func (c *Client) GetAccessProfile(ctx context.Context, id string) (*AccessProfileAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("access profile ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting access profile", map[string]any{"id": id})
+
+	var ap AccessProfileAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&ap).
+		SetPathParam("id", id).
+		Get(accessProfileEndpointGet)
+
+	if err != nil {
+		return nil, c.formatAccessProfileError(accessProfileErrorContext{Operation: "get", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatAccessProfileError(
+			accessProfileErrorContext{Operation: "get", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved access profile", map[string]any{"id": id, "name": ap.Name})
+	return &ap, nil
+}
+
+func (c *Client) CreateAccessProfile(ctx context.Context, ap *AccessProfileAPI) (*AccessProfileAPI, error) {
+	if ap == nil {
+		return nil, fmt.Errorf("access profile cannot be nil")
+	}
+	if ap.Name == "" {
+		return nil, fmt.Errorf("access profile name cannot be empty")
+	}
+
+	requestBody, _ := json.Marshal(ap)
+	tflog.Debug(ctx, "Creating access profile", map[string]any{
+		"name":         ap.Name,
+		"request_body": string(requestBody),
+	})
+
+	var result AccessProfileAPI
+	resp, err := c.prepareRequest(ctx).
+		SetBody(ap).
+		SetResult(&result).
+		Post(accessProfileEndpointCreate)
+
+	if err != nil {
+		return nil, c.formatAccessProfileError(accessProfileErrorContext{Operation: "create", Name: ap.Name}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatAccessProfileError(
+			accessProfileErrorContext{Operation: "create", Name: ap.Name, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully created access profile", map[string]any{"id": result.ID, "name": result.Name})
+	return &result, nil
+}
+
+func (c *Client) PatchAccessProfile(ctx context.Context, id string, patchOps []JSONPatchOperation) (*AccessProfileAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("access profile ID cannot be empty")
+	}
+	if len(patchOps) == 0 {
+		return c.GetAccessProfile(ctx, id)
+	}
+
+	requestBody, _ := json.Marshal(patchOps)
+	tflog.Debug(ctx, "Updating access profile (PATCH)", map[string]any{
+		"id":               id,
+		"operations_count": len(patchOps),
+		"request_body":     string(requestBody),
+	})
+
+	var result AccessProfileAPI
+	resp, err := c.prepareRequest(ctx).
+		SetHeader("Content-Type", "application/json-patch+json").
+		SetBody(patchOps).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Patch(accessProfileEndpointPatch)
+
+	if err != nil {
+		return nil, c.formatAccessProfileError(accessProfileErrorContext{Operation: "update", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatAccessProfileError(
+			accessProfileErrorContext{Operation: "update", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated access profile", map[string]any{"id": id, "name": result.Name})
+	return &result, nil
+}
+
+func (c *Client) DeleteAccessProfile(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("access profile ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Deleting access profile", map[string]any{"id": id})
+
+	resp, err := c.prepareRequest(ctx).
+		SetPathParam("id", id).
+		Delete(accessProfileEndpointDelete)
+
+	if err != nil {
+		return c.formatAccessProfileError(accessProfileErrorContext{Operation: "delete", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		if resp.StatusCode() == http.StatusNotFound {
+			tflog.Debug(ctx, "Access profile not found, treating as already deleted", map[string]any{"id": id})
+			return nil
+		}
+		return c.formatAccessProfileError(
+			accessProfileErrorContext{Operation: "delete", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully deleted access profile", map[string]any{"id": id})
+	return nil
+}
+
+func (c *Client) formatAccessProfileError(errCtx accessProfileErrorContext, err error, statusCode int) error {
+	var baseMsg string
+	switch {
+	case errCtx.ID != "":
+		baseMsg = fmt.Sprintf("failed to %s access profile '%s'", errCtx.Operation, errCtx.ID)
+	case errCtx.Name != "":
+		baseMsg = fmt.Sprintf("failed to %s access profile '%s'", errCtx.Operation, errCtx.Name)
+	default:
+		baseMsg = fmt.Sprintf("failed to %s access profile", errCtx.Operation)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusConflict:
+			return fmt.Errorf("%s: conflict (409)%s", baseMsg, detail)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/access_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/entitlement"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/form_definition"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_attribute"
@@ -164,6 +165,7 @@ func (p *sailpointProvider) Configure(ctx context.Context, req provider.Configur
 // DataSources defines the data sources implemented in the provider.
 func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		access_profile.NewAccessProfileDataSource,
 		entitlement.NewEntitlementDataSource,
 		form_definition.NewFormDefinitionDataSource,
 		identity_attribute.NewIdentityAttributeDataSource,
@@ -182,6 +184,7 @@ func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.D
 // Resources defines the resources implemented in the provider.
 func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		access_profile.NewAccessProfileResource,
 		entitlement.NewEntitlementResource,
 		form_definition.NewFormDefinitionResource,
 		identity_attribute.NewIdentityAttributeResource,

--- a/internal/services/access_profile/access_profile_data_source.go
+++ b/internal/services/access_profile/access_profile_data_source.go
@@ -1,0 +1,189 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package access_profile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &accessProfileDataSource{}
+	_ datasource.DataSourceWithConfigure = &accessProfileDataSource{}
+)
+
+type accessProfileDataSource struct {
+	client *client.Client
+}
+
+func NewAccessProfileDataSource() datasource.DataSource { return &accessProfileDataSource{} }
+
+func (d *accessProfileDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_access_profile"
+}
+
+func (d *accessProfileDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "access profile data source")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = c
+}
+
+func computedObjectRef() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Computed: true,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{Computed: true},
+			"id":   schema.StringAttribute{Computed: true},
+			"name": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *accessProfileDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data source for SailPoint Access Profile.",
+		Attributes: map[string]schema.Attribute{
+			"id":          schema.StringAttribute{Required: true},
+			"name":        schema.StringAttribute{Computed: true},
+			"description": schema.StringAttribute{Computed: true},
+			"enabled":     schema.BoolAttribute{Computed: true},
+			"requestable": schema.BoolAttribute{Computed: true},
+			"owner":       computedObjectRef(),
+			"source":      computedObjectRef(),
+			"entitlements": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{Computed: true},
+						"id":   schema.StringAttribute{Computed: true},
+						"name": schema.StringAttribute{Computed: true},
+					},
+				},
+			},
+			"segments": schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"additional_owners": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{Computed: true},
+						"id":   schema.StringAttribute{Computed: true},
+						"name": schema.StringAttribute{Computed: true},
+					},
+				},
+			},
+			"access_request_config": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"comments_required":        schema.BoolAttribute{Computed: true},
+					"denial_comments_required": schema.BoolAttribute{Computed: true},
+					"reauthorization_required": schema.BoolAttribute{Computed: true},
+					"require_end_date":         schema.BoolAttribute{Computed: true},
+					"max_permitted_access_duration": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"value":     schema.Int64Attribute{Computed: true},
+							"time_unit": schema.StringAttribute{Computed: true},
+						},
+					},
+					"approval_schemes": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"approver_type": schema.StringAttribute{Computed: true},
+								"approver_id":   schema.StringAttribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"revoke_request_config": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"approval_schemes": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"approver_type": schema.StringAttribute{Computed: true},
+								"approver_id":   schema.StringAttribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"provisioning_criteria": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"operation": schema.StringAttribute{Computed: true},
+					"attribute": schema.StringAttribute{Computed: true},
+					"value":     schema.StringAttribute{Computed: true},
+					"children": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"operation": schema.StringAttribute{Computed: true},
+								"attribute": schema.StringAttribute{Computed: true},
+								"value":     schema.StringAttribute{Computed: true},
+								"children": schema.ListNestedAttribute{
+									Computed: true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"operation": schema.StringAttribute{Computed: true},
+											"attribute": schema.StringAttribute{Computed: true},
+											"value":     schema.StringAttribute{Computed: true},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created":  schema.StringAttribute{Computed: true},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *accessProfileDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state accessProfileModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, "Reading access profile data source", map[string]any{"id": id})
+
+	apiResp, err := d.client.GetAccessProfile(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Access Profile",
+			fmt.Sprintf("Could not read access profile %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Access Profile", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/services/access_profile/access_profile_model.go
+++ b/internal/services/access_profile/access_profile_model.go
@@ -1,0 +1,547 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package access_profile
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Terraform models
+// ---------------------------------------------------------------------------
+
+type approvalSchemeModel struct {
+	ApproverType types.String `tfsdk:"approver_type"`
+	ApproverID   types.String `tfsdk:"approver_id"`
+}
+
+type accessDurationModel struct {
+	Value    types.Int64  `tfsdk:"value"`
+	TimeUnit types.String `tfsdk:"time_unit"`
+}
+
+type accessRequestConfigModel struct {
+	CommentsRequired           types.Bool            `tfsdk:"comments_required"`
+	DenialCommentsRequired     types.Bool            `tfsdk:"denial_comments_required"`
+	ReauthorizationRequired    types.Bool            `tfsdk:"reauthorization_required"`
+	RequireEndDate             types.Bool            `tfsdk:"require_end_date"`
+	MaxPermittedAccessDuration *accessDurationModel  `tfsdk:"max_permitted_access_duration"`
+	ApprovalSchemes            []approvalSchemeModel `tfsdk:"approval_schemes"`
+}
+
+type revokeRequestConfigModel struct {
+	ApprovalSchemes []approvalSchemeModel `tfsdk:"approval_schemes"`
+}
+
+type additionalOwnerModel struct {
+	Type types.String `tfsdk:"type"`
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+// Three flattened levels for the provisioning criteria tree (max depth per SailPoint constraint).
+type provisioningCriteriaLevel3Model struct {
+	Operation types.String `tfsdk:"operation"`
+	Attribute types.String `tfsdk:"attribute"`
+	Value     types.String `tfsdk:"value"`
+}
+
+type provisioningCriteriaLevel2Model struct {
+	Operation types.String                      `tfsdk:"operation"`
+	Attribute types.String                      `tfsdk:"attribute"`
+	Value     types.String                      `tfsdk:"value"`
+	Children  []provisioningCriteriaLevel3Model `tfsdk:"children"`
+}
+
+type provisioningCriteriaModel struct {
+	Operation types.String                      `tfsdk:"operation"`
+	Attribute types.String                      `tfsdk:"attribute"`
+	Value     types.String                      `tfsdk:"value"`
+	Children  []provisioningCriteriaLevel2Model `tfsdk:"children"`
+}
+
+type accessProfileModel struct {
+	ID                   types.String               `tfsdk:"id"`
+	Name                 types.String               `tfsdk:"name"`
+	Description          types.String               `tfsdk:"description"`
+	Enabled              types.Bool                 `tfsdk:"enabled"`
+	Requestable          types.Bool                 `tfsdk:"requestable"`
+	Owner                *common.ObjectRefModel     `tfsdk:"owner"`
+	Source               *common.ObjectRefModel     `tfsdk:"source"`
+	Entitlements         []common.ObjectRefModel    `tfsdk:"entitlements"`
+	Segments             types.Set                  `tfsdk:"segments"`
+	AdditionalOwners     []additionalOwnerModel     `tfsdk:"additional_owners"`
+	AccessRequestConfig  *accessRequestConfigModel  `tfsdk:"access_request_config"`
+	RevokeRequestConfig  *revokeRequestConfigModel  `tfsdk:"revoke_request_config"`
+	ProvisioningCriteria *provisioningCriteriaModel `tfsdk:"provisioning_criteria"`
+	Created              types.String               `tfsdk:"created"`
+	Modified             types.String               `tfsdk:"modified"`
+}
+
+// ---------------------------------------------------------------------------
+// FromAPI
+// ---------------------------------------------------------------------------
+
+func (m *accessProfileModel) FromAPI(ctx context.Context, api *client.AccessProfileAPI) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	m.ID = types.StringValue(api.ID)
+	m.Name = types.StringValue(api.Name)
+	m.Description = common.StringOrNull(api.Description)
+	m.Enabled = boolPtrToTF(api.Enabled)
+	m.Requestable = boolPtrToTF(api.Requestable)
+
+	if api.Created != nil {
+		m.Created = types.StringValue(*api.Created)
+	} else {
+		m.Created = types.StringNull()
+	}
+	if api.Modified != nil {
+		m.Modified = types.StringValue(*api.Modified)
+	} else {
+		m.Modified = types.StringNull()
+	}
+
+	owner, diags := common.NewObjectRefFromAPIPtr(ctx, api.Owner)
+	diagnostics.Append(diags...)
+	m.Owner = owner
+
+	source, diags := common.NewObjectRefFromAPIPtr(ctx, api.Source)
+	diagnostics.Append(diags...)
+	m.Source = source
+
+	if len(api.Entitlements) > 0 {
+		m.Entitlements = make([]common.ObjectRefModel, 0, len(api.Entitlements))
+		for i := range api.Entitlements {
+			ref, d := common.NewObjectRefFromAPI(ctx, api.Entitlements[i])
+			diagnostics.Append(d...)
+			m.Entitlements = append(m.Entitlements, ref)
+		}
+	} else {
+		m.Entitlements = nil
+	}
+
+	if api.Segments != nil {
+		segs, d := types.SetValueFrom(ctx, types.StringType, api.Segments)
+		diagnostics.Append(d...)
+		m.Segments = segs
+	} else {
+		m.Segments = types.SetNull(types.StringType)
+	}
+
+	if len(api.AdditionalOwners) > 0 {
+		m.AdditionalOwners = make([]additionalOwnerModel, 0, len(api.AdditionalOwners))
+		for i := range api.AdditionalOwners {
+			m.AdditionalOwners = append(m.AdditionalOwners, additionalOwnerModel{
+				Type: types.StringValue(api.AdditionalOwners[i].Type),
+				ID:   types.StringValue(api.AdditionalOwners[i].ID),
+				Name: types.StringValue(api.AdditionalOwners[i].Name),
+			})
+		}
+	} else {
+		m.AdditionalOwners = nil
+	}
+
+	m.AccessRequestConfig = accessRequestConfigFromAPI(api.AccessRequestConfig)
+	m.RevokeRequestConfig = revokeRequestConfigFromAPI(api.RevokeRequestConfig)
+	m.ProvisioningCriteria = provisioningCriteriaFromAPI(api.ProvisioningCriteria)
+
+	return diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// ToAPI
+// ---------------------------------------------------------------------------
+
+func (m *accessProfileModel) ToAPI(ctx context.Context) (*client.AccessProfileAPI, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+
+	api := &client.AccessProfileAPI{
+		Name: m.Name.ValueString(),
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		v := m.Description.ValueString()
+		api.Description = &v
+	}
+	if !m.Enabled.IsNull() && !m.Enabled.IsUnknown() {
+		v := m.Enabled.ValueBool()
+		api.Enabled = &v
+	}
+	if !m.Requestable.IsNull() && !m.Requestable.IsUnknown() {
+		v := m.Requestable.ValueBool()
+		api.Requestable = &v
+	}
+
+	if m.Owner != nil {
+		ownerAPI, diags := common.NewObjectRefToAPI(ctx, *m.Owner)
+		diagnostics.Append(diags...)
+		api.Owner = ownerAPI
+	}
+	if m.Source != nil {
+		sourceAPI, diags := common.NewObjectRefToAPI(ctx, *m.Source)
+		diagnostics.Append(diags...)
+		api.Source = sourceAPI
+	}
+
+	if len(m.Entitlements) > 0 {
+		api.Entitlements = make([]client.ObjectRefAPI, 0, len(m.Entitlements))
+		for i := range m.Entitlements {
+			ref, d := common.NewObjectRefToAPI(ctx, m.Entitlements[i])
+			diagnostics.Append(d...)
+			api.Entitlements = append(api.Entitlements, ref)
+		}
+	}
+
+	if !m.Segments.IsNull() && !m.Segments.IsUnknown() {
+		var segs []string
+		diagnostics.Append(m.Segments.ElementsAs(ctx, &segs, false)...)
+		api.Segments = segs
+	}
+
+	if len(m.AdditionalOwners) > 0 {
+		api.AdditionalOwners = make([]client.ObjectRefAPI, 0, len(m.AdditionalOwners))
+		for i := range m.AdditionalOwners {
+			api.AdditionalOwners = append(api.AdditionalOwners, client.ObjectRefAPI{
+				Type: m.AdditionalOwners[i].Type.ValueString(),
+				ID:   m.AdditionalOwners[i].ID.ValueString(),
+			})
+		}
+	}
+
+	api.AccessRequestConfig = accessRequestConfigToAPI(m.AccessRequestConfig)
+	api.RevokeRequestConfig = revokeRequestConfigToAPI(m.RevokeRequestConfig)
+	api.ProvisioningCriteria = provisioningCriteriaToAPI(m.ProvisioningCriteria)
+
+	return api, diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// ToPatchOperations
+// ---------------------------------------------------------------------------
+
+func (m *accessProfileModel) ToPatchOperations(ctx context.Context, state *accessProfileModel) ([]client.JSONPatchOperation, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	var ops []client.JSONPatchOperation
+
+	if !m.Name.Equal(state.Name) {
+		ops = append(ops, client.NewReplacePatch("/name", m.Name.ValueString()))
+	}
+	if !m.Description.Equal(state.Description) {
+		if !m.Description.IsNull() {
+			ops = append(ops, client.NewReplacePatch("/description", m.Description.ValueString()))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/description"))
+		}
+	}
+	if !m.Enabled.Equal(state.Enabled) && !m.Enabled.IsNull() && !m.Enabled.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/enabled", m.Enabled.ValueBool()))
+	}
+	if !m.Requestable.Equal(state.Requestable) && !m.Requestable.IsNull() && !m.Requestable.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/requestable", m.Requestable.ValueBool()))
+	}
+
+	if !reflect.DeepEqual(m.Owner, state.Owner) && m.Owner != nil {
+		ownerAPI, d := common.NewObjectRefToAPI(ctx, *m.Owner)
+		diagnostics.Append(d...)
+		ops = append(ops, client.NewReplacePatch("/owner", ownerAPI))
+	}
+
+	// Source + entitlements can be patched together if source changed (API constraint);
+	// otherwise each can be patched independently.
+	sourceChanged := !reflect.DeepEqual(m.Source, state.Source)
+	entsChanged := !reflect.DeepEqual(m.Entitlements, state.Entitlements)
+
+	if sourceChanged && m.Source != nil {
+		srcAPI, d := common.NewObjectRefToAPI(ctx, *m.Source)
+		diagnostics.Append(d...)
+		ops = append(ops, client.NewReplacePatch("/source", srcAPI))
+	}
+	if entsChanged || sourceChanged {
+		ents := make([]client.ObjectRefAPI, 0, len(m.Entitlements))
+		for i := range m.Entitlements {
+			ref, d := common.NewObjectRefToAPI(ctx, m.Entitlements[i])
+			diagnostics.Append(d...)
+			ents = append(ents, ref)
+		}
+		ops = append(ops, client.NewReplacePatch("/entitlements", ents))
+	}
+
+	if !m.Segments.Equal(state.Segments) {
+		if !m.Segments.IsNull() && !m.Segments.IsUnknown() {
+			var segs []string
+			diagnostics.Append(m.Segments.ElementsAs(ctx, &segs, false)...)
+			ops = append(ops, client.NewReplacePatch("/segments", segs))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/segments"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.AdditionalOwners, state.AdditionalOwners) {
+		if m.AdditionalOwners != nil {
+			refs := make([]client.ObjectRefAPI, 0, len(m.AdditionalOwners))
+			for i := range m.AdditionalOwners {
+				refs = append(refs, client.ObjectRefAPI{
+					Type: m.AdditionalOwners[i].Type.ValueString(),
+					ID:   m.AdditionalOwners[i].ID.ValueString(),
+				})
+			}
+			ops = append(ops, client.NewReplacePatch("/additionalOwners", refs))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/additionalOwners"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.AccessRequestConfig, state.AccessRequestConfig) {
+		if m.AccessRequestConfig != nil {
+			ops = append(ops, client.NewReplacePatch("/accessRequestConfig", accessRequestConfigToAPI(m.AccessRequestConfig)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/accessRequestConfig"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.RevokeRequestConfig, state.RevokeRequestConfig) {
+		if m.RevokeRequestConfig != nil {
+			ops = append(ops, client.NewReplacePatch("/revokeRequestConfig", revokeRequestConfigToAPI(m.RevokeRequestConfig)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/revokeRequestConfig"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.ProvisioningCriteria, state.ProvisioningCriteria) {
+		if m.ProvisioningCriteria != nil {
+			ops = append(ops, client.NewReplacePatch("/provisioningCriteria", provisioningCriteriaToAPI(m.ProvisioningCriteria)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/provisioningCriteria"))
+		}
+	}
+
+	return ops, diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers: access_request_config
+// ---------------------------------------------------------------------------
+
+func accessRequestConfigFromAPI(api *client.RequestabilityAPI) *accessRequestConfigModel {
+	if api == nil {
+		return nil
+	}
+	m := &accessRequestConfigModel{
+		CommentsRequired:        boolPtrToTF(api.CommentsRequired),
+		DenialCommentsRequired:  boolPtrToTF(api.DenialCommentsRequired),
+		ReauthorizationRequired: boolPtrToTF(api.ReauthorizationRequired),
+		RequireEndDate:          boolPtrToTF(api.RequireEndDate),
+	}
+	if api.MaxPermittedAccessDuration != nil {
+		m.MaxPermittedAccessDuration = &accessDurationModel{
+			Value:    int64PtrToTF(api.MaxPermittedAccessDuration.Value),
+			TimeUnit: stringPtrToTF(api.MaxPermittedAccessDuration.TimeUnit),
+		}
+	}
+	if len(api.ApprovalSchemes) > 0 {
+		m.ApprovalSchemes = make([]approvalSchemeModel, 0, len(api.ApprovalSchemes))
+		for _, s := range api.ApprovalSchemes {
+			m.ApprovalSchemes = append(m.ApprovalSchemes, approvalSchemeModel{
+				ApproverType: types.StringValue(s.ApproverType),
+				ApproverID:   stringPtrToTF(s.ApproverID),
+			})
+		}
+	}
+	return m
+}
+
+func accessRequestConfigToAPI(m *accessRequestConfigModel) *client.RequestabilityAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.RequestabilityAPI{}
+	if !m.CommentsRequired.IsNull() && !m.CommentsRequired.IsUnknown() {
+		v := m.CommentsRequired.ValueBool()
+		api.CommentsRequired = &v
+	}
+	if !m.DenialCommentsRequired.IsNull() && !m.DenialCommentsRequired.IsUnknown() {
+		v := m.DenialCommentsRequired.ValueBool()
+		api.DenialCommentsRequired = &v
+	}
+	if !m.ReauthorizationRequired.IsNull() && !m.ReauthorizationRequired.IsUnknown() {
+		v := m.ReauthorizationRequired.ValueBool()
+		api.ReauthorizationRequired = &v
+	}
+	if !m.RequireEndDate.IsNull() && !m.RequireEndDate.IsUnknown() {
+		v := m.RequireEndDate.ValueBool()
+		api.RequireEndDate = &v
+	}
+	if m.MaxPermittedAccessDuration != nil {
+		api.MaxPermittedAccessDuration = &client.AccessDurationAPI{
+			Value:    tfToInt64Ptr(m.MaxPermittedAccessDuration.Value),
+			TimeUnit: tfToStringPtr(m.MaxPermittedAccessDuration.TimeUnit),
+		}
+	}
+	if len(m.ApprovalSchemes) > 0 {
+		api.ApprovalSchemes = make([]client.ApprovalSchemeAPI, 0, len(m.ApprovalSchemes))
+		for _, s := range m.ApprovalSchemes {
+			api.ApprovalSchemes = append(api.ApprovalSchemes, client.ApprovalSchemeAPI{
+				ApproverType: s.ApproverType.ValueString(),
+				ApproverID:   tfToStringPtr(s.ApproverID),
+			})
+		}
+	}
+	return api
+}
+
+func revokeRequestConfigFromAPI(api *client.RevocabilityAPI) *revokeRequestConfigModel {
+	if api == nil {
+		return nil
+	}
+	m := &revokeRequestConfigModel{}
+	if len(api.ApprovalSchemes) > 0 {
+		m.ApprovalSchemes = make([]approvalSchemeModel, 0, len(api.ApprovalSchemes))
+		for _, s := range api.ApprovalSchemes {
+			m.ApprovalSchemes = append(m.ApprovalSchemes, approvalSchemeModel{
+				ApproverType: types.StringValue(s.ApproverType),
+				ApproverID:   stringPtrToTF(s.ApproverID),
+			})
+		}
+	}
+	return m
+}
+
+func revokeRequestConfigToAPI(m *revokeRequestConfigModel) *client.RevocabilityAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.RevocabilityAPI{}
+	if len(m.ApprovalSchemes) > 0 {
+		api.ApprovalSchemes = make([]client.ApprovalSchemeAPI, 0, len(m.ApprovalSchemes))
+		for _, s := range m.ApprovalSchemes {
+			api.ApprovalSchemes = append(api.ApprovalSchemes, client.ApprovalSchemeAPI{
+				ApproverType: s.ApproverType.ValueString(),
+				ApproverID:   tfToStringPtr(s.ApproverID),
+			})
+		}
+	}
+	return api
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers: provisioning_criteria (3-level tree)
+// ---------------------------------------------------------------------------
+
+func provisioningCriteriaFromAPI(api *client.ProvisioningCriteriaAPI) *provisioningCriteriaModel {
+	if api == nil {
+		return nil
+	}
+	m := &provisioningCriteriaModel{
+		Operation: types.StringValue(api.Operation),
+		Attribute: stringPtrToTF(api.Attribute),
+		Value:     stringPtrToTF(api.Value),
+	}
+	if len(api.Children) > 0 {
+		m.Children = make([]provisioningCriteriaLevel2Model, 0, len(api.Children))
+		for i := range api.Children {
+			child := &api.Children[i]
+			lvl2 := provisioningCriteriaLevel2Model{
+				Operation: types.StringValue(child.Operation),
+				Attribute: stringPtrToTF(child.Attribute),
+				Value:     stringPtrToTF(child.Value),
+			}
+			if len(child.Children) > 0 {
+				lvl2.Children = make([]provisioningCriteriaLevel3Model, 0, len(child.Children))
+				for j := range child.Children {
+					leaf := &child.Children[j]
+					lvl2.Children = append(lvl2.Children, provisioningCriteriaLevel3Model{
+						Operation: types.StringValue(leaf.Operation),
+						Attribute: stringPtrToTF(leaf.Attribute),
+						Value:     stringPtrToTF(leaf.Value),
+					})
+				}
+			}
+			m.Children = append(m.Children, lvl2)
+		}
+	}
+	return m
+}
+
+func provisioningCriteriaToAPI(m *provisioningCriteriaModel) *client.ProvisioningCriteriaAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.ProvisioningCriteriaAPI{
+		Operation: m.Operation.ValueString(),
+		Attribute: tfToStringPtr(m.Attribute),
+		Value:     tfToStringPtr(m.Value),
+	}
+	if len(m.Children) > 0 {
+		api.Children = make([]client.ProvisioningCriteriaAPI, 0, len(m.Children))
+		for i := range m.Children {
+			child := &m.Children[i]
+			lvl2 := client.ProvisioningCriteriaAPI{
+				Operation: child.Operation.ValueString(),
+				Attribute: tfToStringPtr(child.Attribute),
+				Value:     tfToStringPtr(child.Value),
+			}
+			if len(child.Children) > 0 {
+				lvl2.Children = make([]client.ProvisioningCriteriaAPI, 0, len(child.Children))
+				for j := range child.Children {
+					leaf := &child.Children[j]
+					lvl2.Children = append(lvl2.Children, client.ProvisioningCriteriaAPI{
+						Operation: leaf.Operation.ValueString(),
+						Attribute: tfToStringPtr(leaf.Attribute),
+						Value:     tfToStringPtr(leaf.Value),
+					})
+				}
+			}
+			api.Children = append(api.Children, lvl2)
+		}
+	}
+	return api
+}
+
+// ---------------------------------------------------------------------------
+// Primitive conversion helpers
+// ---------------------------------------------------------------------------
+
+func boolPtrToTF(b *bool) types.Bool {
+	if b == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*b)
+}
+
+func int64PtrToTF(v *int64) types.Int64 {
+	if v == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(*v)
+}
+
+func stringPtrToTF(s *string) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*s)
+}
+
+func tfToStringPtr(s types.String) *string {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	v := s.ValueString()
+	return &v
+}
+
+func tfToInt64Ptr(v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	val := v.ValueInt64()
+	return &val
+}

--- a/internal/services/access_profile/access_profile_resource.go
+++ b/internal/services/access_profile/access_profile_resource.go
@@ -1,0 +1,361 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package access_profile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &accessProfileResource{}
+	_ resource.ResourceWithConfigure   = &accessProfileResource{}
+	_ resource.ResourceWithImportState = &accessProfileResource{}
+)
+
+type accessProfileResource struct {
+	client *client.Client
+}
+
+func NewAccessProfileResource() resource.Resource { return &accessProfileResource{} }
+
+func (r *accessProfileResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_access_profile"
+}
+
+func (r *accessProfileResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "access profile resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+// objectRefNestedAttr builds a standard SingleNestedAttribute for {type, id, name} refs.
+func objectRefNestedAttr(desc string, required bool) schema.SingleNestedAttribute {
+	attrs := map[string]schema.Attribute{
+		"type": schema.StringAttribute{Required: true},
+		"id":   schema.StringAttribute{Required: true},
+		"name": schema.StringAttribute{
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+	}
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: desc,
+		Required:            required,
+		Optional:            !required,
+		Attributes:          attrs,
+	}
+}
+
+func approvalSchemesAttr(desc string) schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"approver_type": schema.StringAttribute{
+					MarkdownDescription: "One of `APP_OWNER`, `OWNER`, `SOURCE_OWNER`, `MANAGER`, `GOVERNANCE_GROUP`, `WORKFLOW`.",
+					Required:            true,
+				},
+				"approver_id": schema.StringAttribute{
+					MarkdownDescription: "ID of the approver. Required when `approver_type` is `GOVERNANCE_GROUP` or `WORKFLOW`.",
+					Optional:            true,
+				},
+			},
+		},
+	}
+}
+
+// level3Attrs is the leaf level of the provisioning criteria tree — no further children.
+func level3Attrs() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"operation": schema.StringAttribute{Required: true},
+		"attribute": schema.StringAttribute{Optional: true},
+		"value":     schema.StringAttribute{Optional: true},
+	}
+}
+
+func (r *accessProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description:         "Resource for SailPoint Access Profile.",
+		MarkdownDescription: "Resource for SailPoint Access Profile. Access profiles bundle entitlements from a single source into a reusable unit that can be assigned to roles or requested directly.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the access profile.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The name of the access profile.",
+			},
+			"description": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Description (max 2000 characters).",
+			},
+			"enabled": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the access profile is enabled. When `true`, at least one entitlement must be provided.",
+			},
+			"requestable": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the access profile can be requested. Defaults to `true`.",
+			},
+			"owner":  objectRefNestedAttr("The owner of the access profile. Typically `type = IDENTITY`.", true),
+			"source": objectRefNestedAttr("The source the access profile draws entitlements from. `type = SOURCE`.", true),
+			"entitlements": schema.SetNestedAttribute{
+				MarkdownDescription: "Entitlements bundled into this access profile.",
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{Required: true},
+						"id":   schema.StringAttribute{Required: true},
+						"name": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"segments": schema.SetAttribute{
+				MarkdownDescription: "Segment UUIDs this access profile is visible in.",
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
+			"additional_owners": schema.SetNestedAttribute{
+				MarkdownDescription: "Additional owners. Each may be `IDENTITY` or `GOVERNANCE_GROUP`.",
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{Required: true},
+						"id":   schema.StringAttribute{Required: true},
+						"name": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"access_request_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Access request configuration.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"comments_required":        schema.BoolAttribute{Optional: true},
+					"denial_comments_required": schema.BoolAttribute{Optional: true},
+					"reauthorization_required": schema.BoolAttribute{Optional: true},
+					"require_end_date":         schema.BoolAttribute{Optional: true},
+					"max_permitted_access_duration": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"value": schema.Int64Attribute{Optional: true},
+							"time_unit": schema.StringAttribute{
+								MarkdownDescription: "One of `HOURS`, `DAYS`, `WEEKS`, `MONTHS`.",
+								Optional:            true,
+							},
+						},
+					},
+					"approval_schemes": approvalSchemesAttr("Ordered approval chain for access requests."),
+				},
+			},
+			"revoke_request_config": schema.SingleNestedAttribute{
+				MarkdownDescription: "Revoke request configuration.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"approval_schemes": approvalSchemesAttr("Ordered approval chain for revoke requests."),
+				},
+			},
+			"provisioning_criteria": schema.SingleNestedAttribute{
+				MarkdownDescription: "Provisioning criteria tree. Max 3 levels deep.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"operation": schema.StringAttribute{
+						MarkdownDescription: "Root operator: `AND`, `OR`, `EQUALS`, `NOT_EQUALS`, `CONTAINS`, `HAS`.",
+						Required:            true,
+					},
+					"attribute": schema.StringAttribute{Optional: true},
+					"value":     schema.StringAttribute{Optional: true},
+					"children": schema.ListNestedAttribute{
+						Optional: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"operation": schema.StringAttribute{Required: true},
+								"attribute": schema.StringAttribute{Optional: true},
+								"value":     schema.StringAttribute{Optional: true},
+								"children": schema.ListNestedAttribute{
+									Optional: true,
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: level3Attrs(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *accessProfileResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan accessProfileModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq, diags := plan.ToAPI(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.CreateAccessProfile(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Creating SailPoint Access Profile",
+			fmt.Sprintf("Could not create access profile %q: %s", plan.Name.ValueString(), err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Creating SailPoint Access Profile", "Received nil response from SailPoint API")
+		return
+	}
+
+	var state accessProfileModel
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "Successfully created access profile", map[string]any{
+		"id":   state.ID.ValueString(),
+		"name": state.Name.ValueString(),
+	})
+}
+
+func (r *accessProfileResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state accessProfileModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	apiResp, err := r.client.GetAccessProfile(ctx, id)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Access profile not found, removing from state", map[string]any{"id": id})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Access Profile",
+			fmt.Sprintf("Could not read access profile %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Access Profile", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *accessProfileResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan accessProfileModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state accessProfileModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	ops, diags := plan.ToPatchOperations(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.PatchAccessProfile(ctx, id, ops)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating SailPoint Access Profile",
+			fmt.Sprintf("Could not update access profile %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Updating SailPoint Access Profile", "Received nil response from SailPoint API")
+		return
+	}
+
+	var newState accessProfileModel
+	resp.Diagnostics.Append(newState.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *accessProfileResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state accessProfileModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	if err := r.client.DeleteAccessProfile(ctx, id); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting SailPoint Access Profile",
+			fmt.Sprintf("Could not delete access profile %q: %s", id, err.Error()),
+		)
+		return
+	}
+}
+
+func (r *accessProfileResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Summary
- New `sailpoint_access_profile` resource + data source backed by `/v2025/access-profiles`
- Full CRUD with JSON Patch updates, ImportState, 404-tolerant delete
- Nested config objects: `access_request_config` (with approval schemes + max permitted access duration), `revoke_request_config`, `additional_owners`, `provisioning_criteria` (3-level flattened tree)
- Special PATCH handling: when `source` changes, `entitlements` is PATCHed alongside (per SailPoint API constraint)
- Examples + import script

Closes #77

## Files added

- `internal/client/access_profiles.go` — CRUD + API types including `RequestabilityAPI`, `RevocabilityAPI`, `AccessDurationAPI`, `ApprovalSchemeAPI`, recursive `ProvisioningCriteriaAPI`
- `internal/services/access_profile/access_profile_model.go` — model + FromAPI/ToAPI/ToPatchOperations with 3-level flattened provisioning criteria
- `internal/services/access_profile/access_profile_resource.go` — resource CRUD + schema + ImportState
- `internal/services/access_profile/access_profile_data_source.go` — read-only data source
- `examples/resources/sailpoint_access_profile/{resource.tf,import.sh}`
- `examples/data-sources/sailpoint_access_profile/main.tf`
- Provider registration

## Test plan

- [x] `make build` — compiles
- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass
- [ ] Acceptance: minimal profile (name + owner + source)
- [ ] Acceptance: full profile with entitlements, approval schemes, provisioning criteria
- [ ] Acceptance: update approval chain via PATCH
- [ ] Acceptance: change source (triggers source + entitlements PATCH)
- [ ] Acceptance: import by ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)