### PR TITLE
feat: add sailpoint_role resource and data source

### DIFF
--- a/examples/data-sources/sailpoint_role/main.tf
+++ b/examples/data-sources/sailpoint_role/main.tf
@@ -1,0 +1,16 @@
+# Look up an existing role by ID
+data "sailpoint_role" "example" {
+  id = "REPLACE_WITH_ROLE_ID"
+}
+
+output "role_name" {
+  value = data.sailpoint_role.example.name
+}
+
+output "role_access_profiles" {
+  value = data.sailpoint_role.example.access_profiles
+}
+
+output "role_membership" {
+  value = data.sailpoint_role.example.membership
+}

--- a/examples/resources/sailpoint_role/import.sh
+++ b/examples/resources/sailpoint_role/import.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Import an existing role by its ID
+terraform import sailpoint_role.engineering "REPLACE_WITH_ROLE_ID"

--- a/examples/resources/sailpoint_role/resource.tf
+++ b/examples/resources/sailpoint_role/resource.tf
@@ -1,0 +1,82 @@
+# Minimal role
+resource "sailpoint_role" "basic" {
+  name = "IT Administrator"
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+}
+
+# Role with access profiles and STANDARD criteria-based membership
+resource "sailpoint_role" "engineering" {
+  name        = "Engineering Role"
+  description = "Grants engineering team access to development tools"
+  enabled     = true
+  requestable = true
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  access_profiles = [
+    { type = "ACCESS_PROFILE", id = "REPLACE_WITH_ACCESS_PROFILE_ID_1" },
+    { type = "ACCESS_PROFILE", id = "REPLACE_WITH_ACCESS_PROFILE_ID_2" },
+  ]
+
+  membership = {
+    type = "STANDARD"
+    criteria = {
+      operation = "AND"
+      children = [
+        {
+          operation = "EQUALS"
+          key = {
+            type     = "IDENTITY"
+            property = "attribute.department"
+          }
+          string_value = "Engineering"
+        },
+        {
+          operation = "EQUALS"
+          key = {
+            type     = "IDENTITY"
+            property = "attribute.cloudLifecycleState"
+          }
+          string_value = "active"
+        },
+      ]
+    }
+  }
+
+  access_request_config = {
+    comments_required        = true
+    denial_comments_required = true
+    approval_schemes = [
+      { approver_type = "MANAGER" },
+      { approver_type = "OWNER" },
+    ]
+  }
+
+  segments = ["REPLACE_WITH_SEGMENT_ID"]
+}
+
+# Role with IDENTITY_LIST membership (explicit identity assignments)
+resource "sailpoint_role" "special_access" {
+  name    = "Special Access Role"
+  enabled = true
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  membership = {
+    type = "IDENTITY_LIST"
+    identities = [
+      { id = "REPLACE_WITH_IDENTITY_ID_1" },
+      { id = "REPLACE_WITH_IDENTITY_ID_2" },
+    ]
+  }
+}

--- a/internal/client/roles.go
+++ b/internal/client/roles.go
@@ -1,0 +1,261 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	roleEndpointGet    = "/v2025/roles/{id}"
+	roleEndpointCreate = "/v2025/roles"
+	roleEndpointPatch  = "/v2025/roles/{id}"
+	roleEndpointDelete = "/v2025/roles/{id}"
+)
+
+// RoleAPI represents a SailPoint Role from the API.
+type RoleAPI struct {
+	ID                  string                  `json:"id,omitempty"`
+	Name                string                  `json:"name"`
+	Description         *string                 `json:"description,omitempty"`
+	Enabled             *bool                   `json:"enabled,omitempty"`
+	Requestable         *bool                   `json:"requestable,omitempty"`
+	Dimensional         *bool                   `json:"dimensional,omitempty"`
+	Owner               ObjectRefAPI            `json:"owner"`
+	AccessProfiles      []ObjectRefAPI          `json:"accessProfiles,omitempty"`
+	Entitlements        []ObjectRefAPI          `json:"entitlements,omitempty"`
+	Segments            []string                `json:"segments,omitempty"`
+	AdditionalOwners    []ObjectRefAPI          `json:"additionalOwners,omitempty"`
+	Membership          *RoleMembershipAPI      `json:"membership,omitempty"`
+	AccessRequestConfig *RequestabilityAPI      `json:"accessRequestConfig,omitempty"`
+	RevokeRequestConfig *RevocabilityForRoleAPI `json:"revokeRequestConfig,omitempty"`
+	DimensionRefs       []ObjectRefAPI          `json:"dimensionRefs,omitempty"`
+	Created             *string                 `json:"created,omitempty"`
+	Modified            *string                 `json:"modified,omitempty"`
+}
+
+// RoleMembershipAPI is a discriminated union. Type="STANDARD" uses Criteria; Type="IDENTITY_LIST" uses Identities.
+type RoleMembershipAPI struct {
+	Type       string                      `json:"type"`
+	Criteria   *RoleCriteriaAPI            `json:"criteria,omitempty"`
+	Identities []RoleMembershipIdentityAPI `json:"identities,omitempty"`
+}
+
+type RoleMembershipIdentityAPI struct {
+	Type      string `json:"type,omitempty"`
+	ID        string `json:"id"`
+	Name      string `json:"name,omitempty"`
+	AliasName string `json:"aliasName,omitempty"`
+}
+
+// RoleCriteriaAPI is the recursive membership criteria tree. Max 3 levels.
+type RoleCriteriaAPI struct {
+	Operation   string              `json:"operation"`
+	Key         *RoleCriteriaKeyAPI `json:"key,omitempty"`
+	StringValue *string             `json:"stringValue,omitempty"`
+	Children    []RoleCriteriaAPI   `json:"children,omitempty"`
+}
+
+type RoleCriteriaKeyAPI struct {
+	Type     string  `json:"type"`
+	Property string  `json:"property"`
+	SourceID *string `json:"sourceId,omitempty"`
+}
+
+// RevocabilityForRoleAPI is the role-specific revoke config (extends RevocabilityAPI with comment fields).
+type RevocabilityForRoleAPI struct {
+	CommentsRequired       *bool               `json:"commentsRequired,omitempty"`
+	DenialCommentsRequired *bool               `json:"denialCommentsRequired,omitempty"`
+	ApprovalSchemes        []ApprovalSchemeAPI `json:"approvalSchemes,omitempty"`
+}
+
+type roleErrorContext struct {
+	Operation    string
+	ID           string
+	Name         string
+	ResponseBody string
+}
+
+func (c *Client) GetRole(ctx context.Context, id string) (*RoleAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("role ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting role", map[string]any{"id": id})
+
+	var role RoleAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&role).
+		SetPathParam("id", id).
+		Get(roleEndpointGet)
+
+	if err != nil {
+		return nil, c.formatRoleError(roleErrorContext{Operation: "get", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatRoleError(
+			roleErrorContext{Operation: "get", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved role", map[string]any{"id": id, "name": role.Name})
+	return &role, nil
+}
+
+func (c *Client) CreateRole(ctx context.Context, role *RoleAPI) (*RoleAPI, error) {
+	if role == nil {
+		return nil, fmt.Errorf("role cannot be nil")
+	}
+	if role.Name == "" {
+		return nil, fmt.Errorf("role name cannot be empty")
+	}
+
+	requestBody, _ := json.Marshal(role)
+	tflog.Debug(ctx, "Creating role", map[string]any{
+		"name":         role.Name,
+		"request_body": string(requestBody),
+	})
+
+	var result RoleAPI
+	resp, err := c.prepareRequest(ctx).
+		SetBody(role).
+		SetResult(&result).
+		Post(roleEndpointCreate)
+
+	if err != nil {
+		return nil, c.formatRoleError(roleErrorContext{Operation: "create", Name: role.Name}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatRoleError(
+			roleErrorContext{Operation: "create", Name: role.Name, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully created role", map[string]any{"id": result.ID, "name": result.Name})
+	return &result, nil
+}
+
+func (c *Client) PatchRole(ctx context.Context, id string, patchOps []JSONPatchOperation) (*RoleAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("role ID cannot be empty")
+	}
+	if len(patchOps) == 0 {
+		return c.GetRole(ctx, id)
+	}
+
+	requestBody, _ := json.Marshal(patchOps)
+	tflog.Debug(ctx, "Updating role (PATCH)", map[string]any{
+		"id":               id,
+		"operations_count": len(patchOps),
+		"request_body":     string(requestBody),
+	})
+
+	var result RoleAPI
+	resp, err := c.prepareRequest(ctx).
+		SetHeader("Content-Type", "application/json-patch+json").
+		SetBody(patchOps).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Patch(roleEndpointPatch)
+
+	if err != nil {
+		return nil, c.formatRoleError(roleErrorContext{Operation: "update", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatRoleError(
+			roleErrorContext{Operation: "update", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated role", map[string]any{"id": id, "name": result.Name})
+	return &result, nil
+}
+
+func (c *Client) DeleteRole(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("role ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Deleting role", map[string]any{"id": id})
+
+	resp, err := c.prepareRequest(ctx).
+		SetPathParam("id", id).
+		Delete(roleEndpointDelete)
+
+	if err != nil {
+		return c.formatRoleError(roleErrorContext{Operation: "delete", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		if resp.StatusCode() == http.StatusNotFound {
+			tflog.Debug(ctx, "Role not found, treating as already deleted", map[string]any{"id": id})
+			return nil
+		}
+		return c.formatRoleError(
+			roleErrorContext{Operation: "delete", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully deleted role", map[string]any{"id": id})
+	return nil
+}
+
+func (c *Client) formatRoleError(errCtx roleErrorContext, err error, statusCode int) error {
+	var baseMsg string
+	switch {
+	case errCtx.ID != "":
+		baseMsg = fmt.Sprintf("failed to %s role '%s'", errCtx.Operation, errCtx.ID)
+	case errCtx.Name != "":
+		baseMsg = fmt.Sprintf("failed to %s role '%s'", errCtx.Operation, errCtx.Name)
+	default:
+		baseMsg = fmt.Sprintf("failed to %s role", errCtx.Operation)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusConflict:
+			return fmt.Errorf("%s: conflict (409)%s", baseMsg, detail)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/launcher"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/lifecycle_state"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/role"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/segment"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/source"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/transform"
@@ -172,6 +173,7 @@ func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.D
 		identity_profile.NewIdentityProfileDataSource,
 		launcher.NewLauncherDataSource,
 		lifecycle_state.NewLifecycleStateDataSource,
+		role.NewRoleDataSource,
 		segment.NewSegmentDataSource,
 		source.NewSourceDataSource,
 		source.NewSourceSchemaDataSource,
@@ -191,6 +193,7 @@ func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resou
 		identity_profile.NewIdentityProfileResource,
 		launcher.NewLauncherResource,
 		lifecycle_state.NewLifecycleStateResource,
+		role.NewRoleResource,
 		segment.NewSegmentResource,
 		source.NewSourceResource,
 		source.NewSourceSchemaResource,

--- a/internal/services/role/role_data_source.go
+++ b/internal/services/role/role_data_source.go
@@ -1,0 +1,226 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package role
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &roleDataSource{}
+	_ datasource.DataSourceWithConfigure = &roleDataSource{}
+)
+
+type roleDataSource struct {
+	client *client.Client
+}
+
+func NewRoleDataSource() datasource.DataSource { return &roleDataSource{} }
+
+func (d *roleDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_role"
+}
+
+func (d *roleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "role data source")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = c
+}
+
+func computedRef() schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		Computed: true,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{Computed: true},
+			"id":   schema.StringAttribute{Computed: true},
+			"name": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func computedRefSet() schema.SetNestedAttribute {
+	return schema.SetNestedAttribute{
+		Computed: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{Computed: true},
+				"id":   schema.StringAttribute{Computed: true},
+				"name": schema.StringAttribute{Computed: true},
+			},
+		},
+	}
+}
+
+func computedApprovalSchemes() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
+		Computed: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"approver_type": schema.StringAttribute{Computed: true},
+				"approver_id":   schema.StringAttribute{Computed: true},
+			},
+		},
+	}
+}
+
+func computedCriteriaLeaf() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"operation": schema.StringAttribute{Computed: true},
+		"key": schema.SingleNestedAttribute{
+			Computed: true,
+			Attributes: map[string]schema.Attribute{
+				"type":      schema.StringAttribute{Computed: true},
+				"property":  schema.StringAttribute{Computed: true},
+				"source_id": schema.StringAttribute{Computed: true},
+			},
+		},
+		"string_value": schema.StringAttribute{Computed: true},
+	}
+}
+
+func (d *roleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data source for SailPoint Role.",
+		Attributes: map[string]schema.Attribute{
+			"id":              schema.StringAttribute{Required: true},
+			"name":            schema.StringAttribute{Computed: true},
+			"description":     schema.StringAttribute{Computed: true},
+			"enabled":         schema.BoolAttribute{Computed: true},
+			"requestable":     schema.BoolAttribute{Computed: true},
+			"dimensional":     schema.BoolAttribute{Computed: true},
+			"owner":           computedRef(),
+			"access_profiles": computedRefSet(),
+			"entitlements":    computedRefSet(),
+			"dimension_refs":  computedRefSet(),
+			"segments": schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"additional_owners": computedRefSet(),
+			"membership": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"criteria": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"operation": schema.StringAttribute{Computed: true},
+							"key": schema.SingleNestedAttribute{
+								Computed: true,
+								Attributes: map[string]schema.Attribute{
+									"type":      schema.StringAttribute{Computed: true},
+									"property":  schema.StringAttribute{Computed: true},
+									"source_id": schema.StringAttribute{Computed: true},
+								},
+							},
+							"string_value": schema.StringAttribute{Computed: true},
+							"children": schema.ListNestedAttribute{
+								Computed: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"operation": schema.StringAttribute{Computed: true},
+										"key": schema.SingleNestedAttribute{
+											Computed: true,
+											Attributes: map[string]schema.Attribute{
+												"type":      schema.StringAttribute{Computed: true},
+												"property":  schema.StringAttribute{Computed: true},
+												"source_id": schema.StringAttribute{Computed: true},
+											},
+										},
+										"string_value": schema.StringAttribute{Computed: true},
+										"children": schema.ListNestedAttribute{
+											Computed: true,
+											NestedObject: schema.NestedAttributeObject{
+												Attributes: computedCriteriaLeaf(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"identities": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id":         schema.StringAttribute{Computed: true},
+								"type":       schema.StringAttribute{Computed: true},
+								"name":       schema.StringAttribute{Computed: true},
+								"alias_name": schema.StringAttribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"access_request_config": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"comments_required":        schema.BoolAttribute{Computed: true},
+					"denial_comments_required": schema.BoolAttribute{Computed: true},
+					"reauthorization_required": schema.BoolAttribute{Computed: true},
+					"require_end_date":         schema.BoolAttribute{Computed: true},
+					"max_permitted_access_duration": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"value":     schema.Int64Attribute{Computed: true},
+							"time_unit": schema.StringAttribute{Computed: true},
+						},
+					},
+					"approval_schemes": computedApprovalSchemes(),
+				},
+			},
+			"revoke_request_config": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"comments_required":        schema.BoolAttribute{Computed: true},
+					"denial_comments_required": schema.BoolAttribute{Computed: true},
+					"approval_schemes":         computedApprovalSchemes(),
+				},
+			},
+			"created":  schema.StringAttribute{Computed: true},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state roleModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	tflog.Debug(ctx, "Reading role data source", map[string]any{"id": id})
+
+	apiResp, err := d.client.GetRole(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Role",
+			fmt.Sprintf("Could not read role %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Role", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/services/role/role_model.go
+++ b/internal/services/role/role_model.go
@@ -1,0 +1,665 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package role
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+type approvalSchemeModel struct {
+	ApproverType types.String `tfsdk:"approver_type"`
+	ApproverID   types.String `tfsdk:"approver_id"`
+}
+
+type accessDurationModel struct {
+	Value    types.Int64  `tfsdk:"value"`
+	TimeUnit types.String `tfsdk:"time_unit"`
+}
+
+type accessRequestConfigModel struct {
+	CommentsRequired           types.Bool            `tfsdk:"comments_required"`
+	DenialCommentsRequired     types.Bool            `tfsdk:"denial_comments_required"`
+	ReauthorizationRequired    types.Bool            `tfsdk:"reauthorization_required"`
+	RequireEndDate             types.Bool            `tfsdk:"require_end_date"`
+	MaxPermittedAccessDuration *accessDurationModel  `tfsdk:"max_permitted_access_duration"`
+	ApprovalSchemes            []approvalSchemeModel `tfsdk:"approval_schemes"`
+}
+
+// Role revoke config has extra comment fields vs access profile revoke config.
+type revokeRequestConfigModel struct {
+	CommentsRequired       types.Bool            `tfsdk:"comments_required"`
+	DenialCommentsRequired types.Bool            `tfsdk:"denial_comments_required"`
+	ApprovalSchemes        []approvalSchemeModel `tfsdk:"approval_schemes"`
+}
+
+type additionalOwnerModel struct {
+	Type types.String `tfsdk:"type"`
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type membershipIdentityModel struct {
+	ID        types.String `tfsdk:"id"`
+	Type      types.String `tfsdk:"type"`
+	Name      types.String `tfsdk:"name"`
+	AliasName types.String `tfsdk:"alias_name"`
+}
+
+type criteriaKeyModel struct {
+	Type     types.String `tfsdk:"type"`
+	Property types.String `tfsdk:"property"`
+	SourceID types.String `tfsdk:"source_id"`
+}
+
+// Three-level flattened criteria tree.
+type criteriaLevel3Model struct {
+	Operation   types.String      `tfsdk:"operation"`
+	Key         *criteriaKeyModel `tfsdk:"key"`
+	StringValue types.String      `tfsdk:"string_value"`
+}
+
+type criteriaLevel2Model struct {
+	Operation   types.String          `tfsdk:"operation"`
+	Key         *criteriaKeyModel     `tfsdk:"key"`
+	StringValue types.String          `tfsdk:"string_value"`
+	Children    []criteriaLevel3Model `tfsdk:"children"`
+}
+
+type roleCriteriaModel struct {
+	Operation   types.String          `tfsdk:"operation"`
+	Key         *criteriaKeyModel     `tfsdk:"key"`
+	StringValue types.String          `tfsdk:"string_value"`
+	Children    []criteriaLevel2Model `tfsdk:"children"`
+}
+
+type membershipModel struct {
+	Type       types.String              `tfsdk:"type"`
+	Criteria   *roleCriteriaModel        `tfsdk:"criteria"`
+	Identities []membershipIdentityModel `tfsdk:"identities"`
+}
+
+type roleModel struct {
+	ID                  types.String              `tfsdk:"id"`
+	Name                types.String              `tfsdk:"name"`
+	Description         types.String              `tfsdk:"description"`
+	Enabled             types.Bool                `tfsdk:"enabled"`
+	Requestable         types.Bool                `tfsdk:"requestable"`
+	Dimensional         types.Bool                `tfsdk:"dimensional"`
+	Owner               *common.ObjectRefModel    `tfsdk:"owner"`
+	AccessProfiles      []common.ObjectRefModel   `tfsdk:"access_profiles"`
+	Entitlements        []common.ObjectRefModel   `tfsdk:"entitlements"`
+	Segments            types.Set                 `tfsdk:"segments"`
+	AdditionalOwners    []additionalOwnerModel    `tfsdk:"additional_owners"`
+	Membership          *membershipModel          `tfsdk:"membership"`
+	AccessRequestConfig *accessRequestConfigModel `tfsdk:"access_request_config"`
+	RevokeRequestConfig *revokeRequestConfigModel `tfsdk:"revoke_request_config"`
+	DimensionRefs       []common.ObjectRefModel   `tfsdk:"dimension_refs"`
+	Created             types.String              `tfsdk:"created"`
+	Modified            types.String              `tfsdk:"modified"`
+}
+
+// ---------------------------------------------------------------------------
+// FromAPI
+// ---------------------------------------------------------------------------
+
+func (m *roleModel) FromAPI(ctx context.Context, api *client.RoleAPI) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	m.ID = types.StringValue(api.ID)
+	m.Name = types.StringValue(api.Name)
+	m.Description = common.StringOrNull(api.Description)
+	m.Enabled = boolPtrToTF(api.Enabled)
+	m.Requestable = boolPtrToTF(api.Requestable)
+	m.Dimensional = boolPtrToTF(api.Dimensional)
+
+	if api.Created != nil {
+		m.Created = types.StringValue(*api.Created)
+	} else {
+		m.Created = types.StringNull()
+	}
+	if api.Modified != nil {
+		m.Modified = types.StringValue(*api.Modified)
+	} else {
+		m.Modified = types.StringNull()
+	}
+
+	owner, diags := common.NewObjectRefFromAPIPtr(ctx, api.Owner)
+	diagnostics.Append(diags...)
+	m.Owner = owner
+
+	m.AccessProfiles = objectRefSliceFromAPI(ctx, api.AccessProfiles, &diagnostics)
+	m.Entitlements = objectRefSliceFromAPI(ctx, api.Entitlements, &diagnostics)
+	m.DimensionRefs = objectRefSliceFromAPI(ctx, api.DimensionRefs, &diagnostics)
+
+	if api.Segments != nil {
+		segs, d := types.SetValueFrom(ctx, types.StringType, api.Segments)
+		diagnostics.Append(d...)
+		m.Segments = segs
+	} else {
+		m.Segments = types.SetNull(types.StringType)
+	}
+
+	if len(api.AdditionalOwners) > 0 {
+		m.AdditionalOwners = make([]additionalOwnerModel, 0, len(api.AdditionalOwners))
+		for i := range api.AdditionalOwners {
+			m.AdditionalOwners = append(m.AdditionalOwners, additionalOwnerModel{
+				Type: types.StringValue(api.AdditionalOwners[i].Type),
+				ID:   types.StringValue(api.AdditionalOwners[i].ID),
+				Name: types.StringValue(api.AdditionalOwners[i].Name),
+			})
+		}
+	}
+
+	m.Membership = membershipFromAPI(api.Membership)
+	m.AccessRequestConfig = accessRequestConfigFromAPI(api.AccessRequestConfig)
+	m.RevokeRequestConfig = revokeRequestConfigFromAPI(api.RevokeRequestConfig)
+
+	return diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// ToAPI
+// ---------------------------------------------------------------------------
+
+func (m *roleModel) ToAPI(ctx context.Context) (*client.RoleAPI, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+
+	api := &client.RoleAPI{
+		Name: m.Name.ValueString(),
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		v := m.Description.ValueString()
+		api.Description = &v
+	}
+	if !m.Enabled.IsNull() && !m.Enabled.IsUnknown() {
+		v := m.Enabled.ValueBool()
+		api.Enabled = &v
+	}
+	if !m.Requestable.IsNull() && !m.Requestable.IsUnknown() {
+		v := m.Requestable.ValueBool()
+		api.Requestable = &v
+	}
+	if !m.Dimensional.IsNull() && !m.Dimensional.IsUnknown() {
+		v := m.Dimensional.ValueBool()
+		api.Dimensional = &v
+	}
+
+	if m.Owner != nil {
+		ownerAPI, diags := common.NewObjectRefToAPI(ctx, *m.Owner)
+		diagnostics.Append(diags...)
+		api.Owner = ownerAPI
+	}
+
+	api.AccessProfiles = objectRefSliceToAPI(ctx, m.AccessProfiles, &diagnostics)
+	api.Entitlements = objectRefSliceToAPI(ctx, m.Entitlements, &diagnostics)
+	api.DimensionRefs = objectRefSliceToAPI(ctx, m.DimensionRefs, &diagnostics)
+
+	if !m.Segments.IsNull() && !m.Segments.IsUnknown() {
+		var segs []string
+		diagnostics.Append(m.Segments.ElementsAs(ctx, &segs, false)...)
+		api.Segments = segs
+	}
+
+	if len(m.AdditionalOwners) > 0 {
+		api.AdditionalOwners = make([]client.ObjectRefAPI, 0, len(m.AdditionalOwners))
+		for i := range m.AdditionalOwners {
+			api.AdditionalOwners = append(api.AdditionalOwners, client.ObjectRefAPI{
+				Type: m.AdditionalOwners[i].Type.ValueString(),
+				ID:   m.AdditionalOwners[i].ID.ValueString(),
+			})
+		}
+	}
+
+	api.Membership = membershipToAPI(m.Membership)
+	api.AccessRequestConfig = accessRequestConfigToAPI(m.AccessRequestConfig)
+	api.RevokeRequestConfig = revokeRequestConfigToAPI(m.RevokeRequestConfig)
+
+	return api, diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// ToPatchOperations
+// ---------------------------------------------------------------------------
+
+func (m *roleModel) ToPatchOperations(ctx context.Context, state *roleModel) ([]client.JSONPatchOperation, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	var ops []client.JSONPatchOperation
+
+	if !m.Name.Equal(state.Name) {
+		ops = append(ops, client.NewReplacePatch("/name", m.Name.ValueString()))
+	}
+	if !m.Description.Equal(state.Description) {
+		if !m.Description.IsNull() {
+			ops = append(ops, client.NewReplacePatch("/description", m.Description.ValueString()))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/description"))
+		}
+	}
+	if !m.Enabled.Equal(state.Enabled) && !m.Enabled.IsNull() && !m.Enabled.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/enabled", m.Enabled.ValueBool()))
+	}
+	if !m.Requestable.Equal(state.Requestable) && !m.Requestable.IsNull() && !m.Requestable.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/requestable", m.Requestable.ValueBool()))
+	}
+	if !m.Dimensional.Equal(state.Dimensional) && !m.Dimensional.IsNull() && !m.Dimensional.IsUnknown() {
+		ops = append(ops, client.NewReplacePatch("/dimensional", m.Dimensional.ValueBool()))
+	}
+
+	if !reflect.DeepEqual(m.Owner, state.Owner) && m.Owner != nil {
+		ownerAPI, d := common.NewObjectRefToAPI(ctx, *m.Owner)
+		diagnostics.Append(d...)
+		ops = append(ops, client.NewReplacePatch("/owner", ownerAPI))
+	}
+
+	if !reflect.DeepEqual(m.AccessProfiles, state.AccessProfiles) {
+		refs := objectRefSliceToAPI(ctx, m.AccessProfiles, &diagnostics)
+		if refs == nil {
+			refs = []client.ObjectRefAPI{}
+		}
+		ops = append(ops, client.NewReplacePatch("/accessProfiles", refs))
+	}
+	if !reflect.DeepEqual(m.Entitlements, state.Entitlements) {
+		refs := objectRefSliceToAPI(ctx, m.Entitlements, &diagnostics)
+		if refs == nil {
+			refs = []client.ObjectRefAPI{}
+		}
+		ops = append(ops, client.NewReplacePatch("/entitlements", refs))
+	}
+	if !reflect.DeepEqual(m.DimensionRefs, state.DimensionRefs) {
+		refs := objectRefSliceToAPI(ctx, m.DimensionRefs, &diagnostics)
+		if refs == nil {
+			refs = []client.ObjectRefAPI{}
+		}
+		ops = append(ops, client.NewReplacePatch("/dimensionRefs", refs))
+	}
+
+	if !m.Segments.Equal(state.Segments) {
+		if !m.Segments.IsNull() && !m.Segments.IsUnknown() {
+			var segs []string
+			diagnostics.Append(m.Segments.ElementsAs(ctx, &segs, false)...)
+			ops = append(ops, client.NewReplacePatch("/segments", segs))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/segments"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.AdditionalOwners, state.AdditionalOwners) {
+		if m.AdditionalOwners != nil {
+			refs := make([]client.ObjectRefAPI, 0, len(m.AdditionalOwners))
+			for i := range m.AdditionalOwners {
+				refs = append(refs, client.ObjectRefAPI{
+					Type: m.AdditionalOwners[i].Type.ValueString(),
+					ID:   m.AdditionalOwners[i].ID.ValueString(),
+				})
+			}
+			ops = append(ops, client.NewReplacePatch("/additionalOwners", refs))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/additionalOwners"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.Membership, state.Membership) {
+		if m.Membership != nil {
+			ops = append(ops, client.NewReplacePatch("/membership", membershipToAPI(m.Membership)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/membership"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.AccessRequestConfig, state.AccessRequestConfig) {
+		if m.AccessRequestConfig != nil {
+			ops = append(ops, client.NewReplacePatch("/accessRequestConfig", accessRequestConfigToAPI(m.AccessRequestConfig)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/accessRequestConfig"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.RevokeRequestConfig, state.RevokeRequestConfig) {
+		if m.RevokeRequestConfig != nil {
+			ops = append(ops, client.NewReplacePatch("/revokeRequestConfig", revokeRequestConfigToAPI(m.RevokeRequestConfig)))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/revokeRequestConfig"))
+		}
+	}
+
+	return ops, diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers: ObjectRef slices
+// ---------------------------------------------------------------------------
+
+func objectRefSliceFromAPI(ctx context.Context, in []client.ObjectRefAPI, diags *diag.Diagnostics) []common.ObjectRefModel {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]common.ObjectRefModel, 0, len(in))
+	for i := range in {
+		ref, d := common.NewObjectRefFromAPI(ctx, in[i])
+		diags.Append(d...)
+		out = append(out, ref)
+	}
+	return out
+}
+
+func objectRefSliceToAPI(ctx context.Context, in []common.ObjectRefModel, diags *diag.Diagnostics) []client.ObjectRefAPI {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]client.ObjectRefAPI, 0, len(in))
+	for i := range in {
+		ref, d := common.NewObjectRefToAPI(ctx, in[i])
+		diags.Append(d...)
+		out = append(out, ref)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers: access/revoke request configs
+// ---------------------------------------------------------------------------
+
+func accessRequestConfigFromAPI(api *client.RequestabilityAPI) *accessRequestConfigModel {
+	if api == nil {
+		return nil
+	}
+	m := &accessRequestConfigModel{
+		CommentsRequired:        boolPtrToTF(api.CommentsRequired),
+		DenialCommentsRequired:  boolPtrToTF(api.DenialCommentsRequired),
+		ReauthorizationRequired: boolPtrToTF(api.ReauthorizationRequired),
+		RequireEndDate:          boolPtrToTF(api.RequireEndDate),
+	}
+	if api.MaxPermittedAccessDuration != nil {
+		m.MaxPermittedAccessDuration = &accessDurationModel{
+			Value:    int64PtrToTF(api.MaxPermittedAccessDuration.Value),
+			TimeUnit: stringPtrToTF(api.MaxPermittedAccessDuration.TimeUnit),
+		}
+	}
+	if len(api.ApprovalSchemes) > 0 {
+		m.ApprovalSchemes = approvalSchemesFromAPI(api.ApprovalSchemes)
+	}
+	return m
+}
+
+func accessRequestConfigToAPI(m *accessRequestConfigModel) *client.RequestabilityAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.RequestabilityAPI{}
+	if !m.CommentsRequired.IsNull() && !m.CommentsRequired.IsUnknown() {
+		v := m.CommentsRequired.ValueBool()
+		api.CommentsRequired = &v
+	}
+	if !m.DenialCommentsRequired.IsNull() && !m.DenialCommentsRequired.IsUnknown() {
+		v := m.DenialCommentsRequired.ValueBool()
+		api.DenialCommentsRequired = &v
+	}
+	if !m.ReauthorizationRequired.IsNull() && !m.ReauthorizationRequired.IsUnknown() {
+		v := m.ReauthorizationRequired.ValueBool()
+		api.ReauthorizationRequired = &v
+	}
+	if !m.RequireEndDate.IsNull() && !m.RequireEndDate.IsUnknown() {
+		v := m.RequireEndDate.ValueBool()
+		api.RequireEndDate = &v
+	}
+	if m.MaxPermittedAccessDuration != nil {
+		api.MaxPermittedAccessDuration = &client.AccessDurationAPI{
+			Value:    tfToInt64Ptr(m.MaxPermittedAccessDuration.Value),
+			TimeUnit: tfToStringPtr(m.MaxPermittedAccessDuration.TimeUnit),
+		}
+	}
+	if len(m.ApprovalSchemes) > 0 {
+		api.ApprovalSchemes = approvalSchemesToAPI(m.ApprovalSchemes)
+	}
+	return api
+}
+
+func revokeRequestConfigFromAPI(api *client.RevocabilityForRoleAPI) *revokeRequestConfigModel {
+	if api == nil {
+		return nil
+	}
+	m := &revokeRequestConfigModel{
+		CommentsRequired:       boolPtrToTF(api.CommentsRequired),
+		DenialCommentsRequired: boolPtrToTF(api.DenialCommentsRequired),
+	}
+	if len(api.ApprovalSchemes) > 0 {
+		m.ApprovalSchemes = approvalSchemesFromAPI(api.ApprovalSchemes)
+	}
+	return m
+}
+
+func revokeRequestConfigToAPI(m *revokeRequestConfigModel) *client.RevocabilityForRoleAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.RevocabilityForRoleAPI{}
+	if !m.CommentsRequired.IsNull() && !m.CommentsRequired.IsUnknown() {
+		v := m.CommentsRequired.ValueBool()
+		api.CommentsRequired = &v
+	}
+	if !m.DenialCommentsRequired.IsNull() && !m.DenialCommentsRequired.IsUnknown() {
+		v := m.DenialCommentsRequired.ValueBool()
+		api.DenialCommentsRequired = &v
+	}
+	if len(m.ApprovalSchemes) > 0 {
+		api.ApprovalSchemes = approvalSchemesToAPI(m.ApprovalSchemes)
+	}
+	return api
+}
+
+func approvalSchemesFromAPI(in []client.ApprovalSchemeAPI) []approvalSchemeModel {
+	out := make([]approvalSchemeModel, 0, len(in))
+	for _, s := range in {
+		out = append(out, approvalSchemeModel{
+			ApproverType: types.StringValue(s.ApproverType),
+			ApproverID:   stringPtrToTF(s.ApproverID),
+		})
+	}
+	return out
+}
+
+func approvalSchemesToAPI(in []approvalSchemeModel) []client.ApprovalSchemeAPI {
+	out := make([]client.ApprovalSchemeAPI, 0, len(in))
+	for _, s := range in {
+		out = append(out, client.ApprovalSchemeAPI{
+			ApproverType: s.ApproverType.ValueString(),
+			ApproverID:   tfToStringPtr(s.ApproverID),
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers: membership + criteria tree
+// ---------------------------------------------------------------------------
+
+func membershipFromAPI(api *client.RoleMembershipAPI) *membershipModel {
+	if api == nil {
+		return nil
+	}
+	m := &membershipModel{
+		Type: types.StringValue(api.Type),
+	}
+	if api.Criteria != nil {
+		m.Criteria = criteriaFromAPI(api.Criteria)
+	}
+	if len(api.Identities) > 0 {
+		m.Identities = make([]membershipIdentityModel, 0, len(api.Identities))
+		for _, id := range api.Identities {
+			m.Identities = append(m.Identities, membershipIdentityModel{
+				ID:        types.StringValue(id.ID),
+				Type:      types.StringValue(id.Type),
+				Name:      types.StringValue(id.Name),
+				AliasName: types.StringValue(id.AliasName),
+			})
+		}
+	}
+	return m
+}
+
+func membershipToAPI(m *membershipModel) *client.RoleMembershipAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.RoleMembershipAPI{
+		Type: m.Type.ValueString(),
+	}
+	if m.Criteria != nil {
+		api.Criteria = criteriaToAPI(m.Criteria)
+	}
+	if len(m.Identities) > 0 {
+		api.Identities = make([]client.RoleMembershipIdentityAPI, 0, len(m.Identities))
+		for _, id := range m.Identities {
+			api.Identities = append(api.Identities, client.RoleMembershipIdentityAPI{
+				ID:   id.ID.ValueString(),
+				Type: id.Type.ValueString(),
+			})
+		}
+	}
+	return api
+}
+
+func criteriaFromAPI(api *client.RoleCriteriaAPI) *roleCriteriaModel {
+	if api == nil {
+		return nil
+	}
+	m := &roleCriteriaModel{
+		Operation:   types.StringValue(api.Operation),
+		Key:         criteriaKeyFromAPI(api.Key),
+		StringValue: stringPtrToTF(api.StringValue),
+	}
+	if len(api.Children) > 0 {
+		m.Children = make([]criteriaLevel2Model, 0, len(api.Children))
+		for i := range api.Children {
+			child := &api.Children[i]
+			lvl2 := criteriaLevel2Model{
+				Operation:   types.StringValue(child.Operation),
+				Key:         criteriaKeyFromAPI(child.Key),
+				StringValue: stringPtrToTF(child.StringValue),
+			}
+			if len(child.Children) > 0 {
+				lvl2.Children = make([]criteriaLevel3Model, 0, len(child.Children))
+				for j := range child.Children {
+					leaf := &child.Children[j]
+					lvl2.Children = append(lvl2.Children, criteriaLevel3Model{
+						Operation:   types.StringValue(leaf.Operation),
+						Key:         criteriaKeyFromAPI(leaf.Key),
+						StringValue: stringPtrToTF(leaf.StringValue),
+					})
+				}
+			}
+			m.Children = append(m.Children, lvl2)
+		}
+	}
+	return m
+}
+
+func criteriaToAPI(m *roleCriteriaModel) *client.RoleCriteriaAPI {
+	if m == nil {
+		return nil
+	}
+	api := &client.RoleCriteriaAPI{
+		Operation:   m.Operation.ValueString(),
+		Key:         criteriaKeyToAPI(m.Key),
+		StringValue: tfToStringPtr(m.StringValue),
+	}
+	if len(m.Children) > 0 {
+		api.Children = make([]client.RoleCriteriaAPI, 0, len(m.Children))
+		for i := range m.Children {
+			child := &m.Children[i]
+			lvl2 := client.RoleCriteriaAPI{
+				Operation:   child.Operation.ValueString(),
+				Key:         criteriaKeyToAPI(child.Key),
+				StringValue: tfToStringPtr(child.StringValue),
+			}
+			if len(child.Children) > 0 {
+				lvl2.Children = make([]client.RoleCriteriaAPI, 0, len(child.Children))
+				for j := range child.Children {
+					leaf := &child.Children[j]
+					lvl2.Children = append(lvl2.Children, client.RoleCriteriaAPI{
+						Operation:   leaf.Operation.ValueString(),
+						Key:         criteriaKeyToAPI(leaf.Key),
+						StringValue: tfToStringPtr(leaf.StringValue),
+					})
+				}
+			}
+			api.Children = append(api.Children, lvl2)
+		}
+	}
+	return api
+}
+
+func criteriaKeyFromAPI(api *client.RoleCriteriaKeyAPI) *criteriaKeyModel {
+	if api == nil {
+		return nil
+	}
+	return &criteriaKeyModel{
+		Type:     types.StringValue(api.Type),
+		Property: types.StringValue(api.Property),
+		SourceID: stringPtrToTF(api.SourceID),
+	}
+}
+
+func criteriaKeyToAPI(m *criteriaKeyModel) *client.RoleCriteriaKeyAPI {
+	if m == nil {
+		return nil
+	}
+	return &client.RoleCriteriaKeyAPI{
+		Type:     m.Type.ValueString(),
+		Property: m.Property.ValueString(),
+		SourceID: tfToStringPtr(m.SourceID),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Primitive helpers
+// ---------------------------------------------------------------------------
+
+func boolPtrToTF(b *bool) types.Bool {
+	if b == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*b)
+}
+
+func int64PtrToTF(v *int64) types.Int64 {
+	if v == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(*v)
+}
+
+func stringPtrToTF(s *string) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*s)
+}
+
+func tfToStringPtr(s types.String) *string {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	v := s.ValueString()
+	return &v
+}
+
+func tfToInt64Ptr(v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	val := v.ValueInt64()
+	return &val
+}

--- a/internal/services/role/role_resource.go
+++ b/internal/services/role/role_resource.go
@@ -1,0 +1,407 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package role
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &roleResource{}
+	_ resource.ResourceWithConfigure   = &roleResource{}
+	_ resource.ResourceWithImportState = &roleResource{}
+)
+
+type roleResource struct {
+	client *client.Client
+}
+
+func NewRoleResource() resource.Resource { return &roleResource{} }
+
+func (r *roleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_role"
+}
+
+func (r *roleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "role resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+// Shared attribute helpers.
+
+func objectRefSingle(desc string, required bool) schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: desc,
+		Required:            required,
+		Optional:            !required,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{Required: true},
+			"id":   schema.StringAttribute{Required: true},
+			"name": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func objectRefSet(desc string) schema.SetNestedAttribute {
+	return schema.SetNestedAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{Required: true},
+				"id":   schema.StringAttribute{Required: true},
+				"name": schema.StringAttribute{
+					Computed: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func approvalSchemesAttr(desc string) schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
+		MarkdownDescription: desc,
+		Optional:            true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"approver_type": schema.StringAttribute{
+					MarkdownDescription: "One of `OWNER`, `MANAGER`, `GOVERNANCE_GROUP`, `WORKFLOW`.",
+					Required:            true,
+				},
+				"approver_id": schema.StringAttribute{
+					MarkdownDescription: "ID of the approver. Required when `approver_type` is `GOVERNANCE_GROUP` or `WORKFLOW`.",
+					Optional:            true,
+				},
+			},
+		},
+	}
+}
+
+// criteriaLeafAttrs is the level-3 (leaf) criteria attribute set.
+func criteriaLeafAttrs() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"operation": schema.StringAttribute{Required: true},
+		"key": schema.SingleNestedAttribute{
+			Optional: true,
+			Attributes: map[string]schema.Attribute{
+				"type":      schema.StringAttribute{Required: true},
+				"property":  schema.StringAttribute{Required: true},
+				"source_id": schema.StringAttribute{Optional: true},
+			},
+		},
+		"string_value": schema.StringAttribute{Optional: true},
+	}
+}
+
+func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Resource for SailPoint Role.",
+		MarkdownDescription: "Resource for SailPoint Role. Roles are the top of the access hierarchy — they bundle access profiles and" +
+			" entitlements together and can define dynamic membership via criteria-based rules or explicit identity lists.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the role.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The name of the role (max 128 chars).",
+			},
+			"description": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Description (max 2000 chars).",
+			},
+			"enabled":         schema.BoolAttribute{Optional: true, Computed: true, MarkdownDescription: "Whether the role is enabled."},
+			"requestable":     schema.BoolAttribute{Optional: true, Computed: true, MarkdownDescription: "Whether the role can be requested. Defaults to `false`."},
+			"dimensional":     schema.BoolAttribute{Optional: true, Computed: true, MarkdownDescription: "Whether this is a dimensional role."},
+			"owner":           objectRefSingle("The owner of the role. Typically `type = IDENTITY`.", true),
+			"access_profiles": objectRefSet("Access profiles bundled into this role."),
+			"entitlements":    objectRefSet("Entitlements bundled directly into this role."),
+			"segments": schema.SetAttribute{
+				MarkdownDescription: "Segment UUIDs the role is visible in.",
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
+			"additional_owners": schema.SetNestedAttribute{
+				MarkdownDescription: "Additional owners. Each may be `IDENTITY` or `GOVERNANCE_GROUP`.",
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{Required: true},
+						"id":   schema.StringAttribute{Required: true},
+						"name": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+				},
+			},
+			"membership": schema.SingleNestedAttribute{
+				MarkdownDescription: "Role membership rules. `type = STANDARD` uses `criteria`; `type = IDENTITY_LIST` uses `identities`.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						MarkdownDescription: "`STANDARD` or `IDENTITY_LIST`.",
+						Required:            true,
+					},
+					"criteria": schema.SingleNestedAttribute{
+						MarkdownDescription: "Criteria tree for STANDARD membership. Max 3 levels deep.",
+						Optional:            true,
+						Attributes: map[string]schema.Attribute{
+							"operation": schema.StringAttribute{Required: true},
+							"key": schema.SingleNestedAttribute{
+								Optional: true,
+								Attributes: map[string]schema.Attribute{
+									"type":      schema.StringAttribute{Required: true},
+									"property":  schema.StringAttribute{Required: true},
+									"source_id": schema.StringAttribute{Optional: true},
+								},
+							},
+							"string_value": schema.StringAttribute{Optional: true},
+							"children": schema.ListNestedAttribute{
+								Optional: true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"operation": schema.StringAttribute{Required: true},
+										"key": schema.SingleNestedAttribute{
+											Optional: true,
+											Attributes: map[string]schema.Attribute{
+												"type":      schema.StringAttribute{Required: true},
+												"property":  schema.StringAttribute{Required: true},
+												"source_id": schema.StringAttribute{Optional: true},
+											},
+										},
+										"string_value": schema.StringAttribute{Optional: true},
+										"children": schema.ListNestedAttribute{
+											Optional: true,
+											NestedObject: schema.NestedAttributeObject{
+												Attributes: criteriaLeafAttrs(),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"identities": schema.ListNestedAttribute{
+						MarkdownDescription: "Explicit identity list for IDENTITY_LIST membership. Max 500 modifications per PATCH.",
+						Optional:            true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id":   schema.StringAttribute{Required: true},
+								"type": schema.StringAttribute{Optional: true, Computed: true},
+								"name": schema.StringAttribute{
+									Computed: true,
+									PlanModifiers: []planmodifier.String{
+										stringplanmodifier.UseStateForUnknown(),
+									},
+								},
+								"alias_name": schema.StringAttribute{
+									Computed: true,
+									PlanModifiers: []planmodifier.String{
+										stringplanmodifier.UseStateForUnknown(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"access_request_config": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"comments_required":        schema.BoolAttribute{Optional: true},
+					"denial_comments_required": schema.BoolAttribute{Optional: true},
+					"reauthorization_required": schema.BoolAttribute{Optional: true},
+					"require_end_date":         schema.BoolAttribute{Optional: true},
+					"max_permitted_access_duration": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"value":     schema.Int64Attribute{Optional: true},
+							"time_unit": schema.StringAttribute{Optional: true},
+						},
+					},
+					"approval_schemes": approvalSchemesAttr("Ordered approval chain for access requests."),
+				},
+			},
+			"revoke_request_config": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"comments_required":        schema.BoolAttribute{Optional: true},
+					"denial_comments_required": schema.BoolAttribute{Optional: true},
+					"approval_schemes":         approvalSchemesAttr("Ordered approval chain for revoke requests."),
+				},
+			},
+			"dimension_refs": objectRefSet("Dimensions referenced by this role (when dimensional=true)."),
+			"created": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan roleModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq, diags := plan.ToAPI(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.CreateRole(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Creating SailPoint Role",
+			fmt.Sprintf("Could not create role %q: %s", plan.Name.ValueString(), err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Creating SailPoint Role", "Received nil response from SailPoint API")
+		return
+	}
+
+	var state roleModel
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "Successfully created role", map[string]any{
+		"id":   state.ID.ValueString(),
+		"name": state.Name.ValueString(),
+	})
+}
+
+func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state roleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	apiResp, err := r.client.GetRole(ctx, id)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Role not found, removing from state", map[string]any{"id": id})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Role",
+			fmt.Sprintf("Could not read role %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Role", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan roleModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state roleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	ops, diags := plan.ToPatchOperations(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.PatchRole(ctx, id, ops)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating SailPoint Role",
+			fmt.Sprintf("Could not update role %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Updating SailPoint Role", "Received nil response from SailPoint API")
+		return
+	}
+
+	var newState roleModel
+	resp.Diagnostics.Append(newState.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state roleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	if err := r.client.DeleteRole(ctx, id); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting SailPoint Role",
+			fmt.Sprintf("Could not delete role %q: %s", id, err.Error()),
+		)
+		return
+	}
+}
+
+func (r *roleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Summary
- New `sailpoint_role` resource + data source backed by `/v2025/roles`
- Full CRUD with JSON Patch updates, ImportState, 404-tolerant delete
- Union-typed `membership`: `STANDARD` (criteria tree) or `IDENTITY_LIST`
- 3-level flattened criteria tree with `key` type/property/source_id
- Role-specific `revoke_request_config` with `comments_required` + `denial_comments_required` (distinct from access profile revoke config)
- `dimensional` flag + `dimension_refs`
- Reuses `RequestabilityAPI`, `AccessDurationAPI`, `ApprovalSchemeAPI` from `internal/client/access_profiles.go`

**Stacked on #85** (access_profile) — merge that first, or GitHub will auto-retarget this to `main` after #85 lands.

Closes #78

## Files added

- `internal/client/roles.go` — CRUD + API types (`RoleAPI`, `RoleMembershipAPI`, `RoleCriteriaAPI`, `RoleCriteriaKeyAPI`, `RoleMembershipIdentityAPI`, `RevocabilityForRoleAPI`)
- `internal/services/role/role_model.go` — model + FromAPI/ToAPI/ToPatchOperations; union membership + 3-level criteria tree
- `internal/services/role/role_resource.go` — resource CRUD + schema + ImportState
- `internal/services/role/role_data_source.go` — read-only data source
- `examples/resources/sailpoint_role/{resource.tf,import.sh}` — minimal, STANDARD-criteria, and IDENTITY_LIST examples
- `examples/data-sources/sailpoint_role/main.tf`
- Provider registration

## Test plan

- [x] `make build` — compiles
- [x] `make lint` — 0 issues
- [x] `make test` — all unit tests pass
- [ ] Acceptance: minimal role (name + owner)
- [ ] Acceptance: role with access profiles and STANDARD criteria (2-level AND)
- [ ] Acceptance: role with IDENTITY_LIST membership
- [ ] Acceptance: update membership type (STANDARD → IDENTITY_LIST)
- [ ] Acceptance: update approval chain via PATCH
- [ ] Acceptance: import by ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)