### PR TITLE
fix(ci): grant workflow permissions for Lock Threads and Issue Comment Triage

### DIFF
--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   issue_comment_triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '43 20 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Two workflows were failing with ``Resource not accessible by integration`` because the default `GITHUB_TOKEN` doesn't grant `issues:write` or `pull-requests:write` by default — those must be declared explicitly.

**Fixed:**
- `Lock Threads` (scheduled) — needs permissions to lock inactive issues/PRs. Last failure: run [24316221266](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/actions/runs/24316221266)
- `Issue Comment Triage` (issue_comment trigger) — calls `gh issue edit --remove-label waiting-response`. Last failures: runs 24311875301, 24307319431, 24307301303

Both now get an explicit `permissions:` block with `issues: write` and `pull-requests: write`.

## Test plan
- [x] Workflow YAML syntax valid
- [ ] Next scheduled Lock Threads run succeeds (tomorrow 20:43 UTC)
- [ ] Next issue comment doesn't fail the triage workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)