### PR TITLE
fix(ci): tolerate missing waiting-response label in triage workflow

### DIFF
--- a/.github/workflows/issue-comment-triage.yml
+++ b/.github/workflows/issue-comment-triage.yml
@@ -22,4 +22,13 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: 'Remove waiting-response on comment'
-        run: gh ${{ env.COMMAND }} edit ${{ github.event.issue.html_url }} --remove-label waiting-response
+        # The label may not be present on every issue/PR — tolerate "not found"
+        # so the workflow doesn't fail for every unrelated comment.
+        run: |
+          gh ${{ env.COMMAND }} edit ${{ github.event.issue.html_url }} --remove-label waiting-response 2>&1 | tee /tmp/triage.log || {
+            if grep -q "'waiting-response' not found" /tmp/triage.log; then
+              echo "Label 'waiting-response' was not present — nothing to remove."
+              exit 0
+            fi
+            exit 1
+          }


### PR DESCRIPTION
## Summary

After PR #88 granted the triage workflow `issues:write`, it now runs successfully when the label is present — but it fails for every comment where the label isn't on the issue. Most comments fall into this category.

**Error:** ``failed to update <url>: 'waiting-response' not found``

**Fix:** wrap the ``gh issue edit`` call so the ``not found`` case is treated as a no-op. Other errors (auth, rate limit, etc.) still fail the step.

## Test plan
- [x] YAML syntax valid
- [ ] Next comment on an issue without the label succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)