### PR TITLE
fix: workflow execution_count/failure_count are live metrics

### DIFF
--- a/internal/services/workflow/workflow_resource.go
+++ b/internal/services/workflow/workflow_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -141,18 +140,12 @@ func (r *workflowResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"execution_count": schema.Int32Attribute{
-				MarkdownDescription: "The number of times the workflow has been executed.",
+				MarkdownDescription: "The number of times the workflow has been executed. Server-side live metric — refreshed on every read; do not assume stable across applies.",
 				Computed:            true,
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.UseStateForUnknown(),
-				},
 			},
 			"failure_count": schema.Int32Attribute{
-				MarkdownDescription: "The number of times the workflow has failed.",
+				MarkdownDescription: "The number of times the workflow has failed. Server-side live metric — refreshed on every read; do not assume stable across applies.",
 				Computed:            true,
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.UseStateForUnknown(),
-				},
 			},
 			"owner": schema.SingleNestedAttribute{
 				MarkdownDescription: "The owner of the workflow.",


### PR DESCRIPTION
## Summary

Drop the ``UseStateForUnknown`` plan modifier on ``execution_count`` and ``failure_count`` in the ``sailpoint_workflow`` resource schema. These fields are server-side live metrics — SailPoint resets them to ``0`` on every PUT update — so the framework was planning the prior value (e.g. ``1``) and then erroring with ``Provider produced inconsistent result after apply`` when Read returned ``0``.

With the plan modifier removed, the framework treats these fields as unknown until refreshed, which matches the underlying semantics: there is no stable user-controlled value to preserve.

Closes #93

## Test plan
- [x] ``make build`` — compiles
- [x] ``make lint`` — 0 issues
- [x] ``make test`` — passes
- [ ] Apply a workflow update on a workflow that has been executed at least once (regression: the bug reproduces in v2.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)