### PR TITLE
fix: surface real API error message on 4xx responses (Closes #81)

### DIFF
--- a/.github/RELEASE_NOTES_v2.4.2.md
+++ b/.github/RELEASE_NOTES_v2.4.2.md
@@ -1,0 +1,20 @@
+# Release v2.4.2 - Surface real API error messages on 4xx
+
+Patch release that fixes a long-standing transport bug where 4xx responses from SailPoint were masked by the misleading `resty: content decoder not found` error, hiding the real API message and forcing users to re-run failed calls manually via `sail api` to discover the actual cause.
+
+## Bug Fixes
+
+- **Error handling**: 4xx responses from SailPoint now surface the real API error message instead of `resty: content decoder not found`. Root cause: the SailPoint edge (Cloudflare) returns a non-standard `Content-Encoding: UTF-8` header on some 4xx responses (`UTF-8` is a charset, not an encoding — the body is plain JSON). Resty v3 only registers `gzip` / `deflate` decompressers by default and bailed before the JSON body could be read. The provider now registers a no-op decompresser keyed on `UTF-8` so the response body reaches the per-resource error formatters. Affects every resource — most visibly transform create with rejected names, identity profile update during background tasks, and any other endpoint hitting a 4xx with this header. Closes #81.
+
+## Notes for upgraders
+
+- The previous mitigation (`Accept-Encoding: identity`) added in v2.4.0 (PR #82) is preserved as a microbenefit on 2xx responses, but it was not effective on 4xx because Cloudflare ignores the header for error responses. v2.4.2 is the first version where the underlying transport behavior is actually fixed.
+- After upgrading, an `apply` that previously failed with `resty: content decoder not found` will fail with the real SailPoint message instead — typically a `400.x.y` `detailCode` plus a human-readable `text` field. This is intentional: you'll now see what to fix.
+
+## Full Changelog
+
+See [CHANGELOG.md](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/blob/main/CHANGELOG.md) for complete details.
+
+---
+
+**Questions or Issues?** Please open an issue on [GitHub](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-04-26
+
+### Fixed
+
+- **Error handling**: 4xx responses from SailPoint no longer surface as the opaque `resty: content decoder not found` error. The SailPoint edge (Cloudflare) returns a non-standard `Content-Encoding: UTF-8` header on some 4xx responses — Resty v3 only knows `gzip`/`deflate` by default and bailed before the JSON body could be read, masking the real API error message. The provider now registers a no-op decompresser for `UTF-8` so the response body flows through to the per-resource error formatters. Affects every resource that hits a 4xx with this header (transform create, identity profile update, etc.). Closes #81.
+
 ## [2.4.1] - 2026-04-13
 
 ### Fixed

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -30,8 +30,8 @@ Manages a SailPoint Workflow. Workflows are custom automation scripts that respo
 
 - `created` (String) The date and time the workflow was created.
 - `creator` (Attributes) The identity who created the workflow. (see [below for nested schema](#nestedatt--creator))
-- `execution_count` (Number) The number of times the workflow has been executed.
-- `failure_count` (Number) The number of times the workflow has failed.
+- `execution_count` (Number) The number of times the workflow has been executed. Server-side live metric — refreshed on every read; do not assume stable across applies.
+- `failure_count` (Number) The number of times the workflow has failed. Server-side live metric — refreshed on every read; do not assume stable across applies.
 - `id` (String) The unique identifier of the workflow.
 - `modified` (String) The date and time the workflow was last modified.
 - `modified_by` (Attributes) The identity who last modified the workflow. (see [below for nested schema](#nestedatt--modified_by))

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -76,6 +77,19 @@ func NewClient(baseURL, clientID, clientSecret string) (*Client, error) {
 			}
 			return nil
 		})
+
+	// Workaround for SailPoint (or its Cloudflare edge) returning a non-standard
+	// Content-Encoding: UTF-8 header on some 4xx responses. UTF-8 is a charset,
+	// not a content encoding — the body is actually plain JSON. Resty v3 only
+	// registers gzip/deflate decompressers by default and bails with
+	// "resty: content decoder not found" for any other value, masking the real
+	// API error message. Registering a no-op decompresser for UTF-8 lets the
+	// JSON body flow through to the per-resource error formatters.
+	// See https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/issues/81
+	noopDecompresser := func(r io.ReadCloser) (io.ReadCloser, error) { return r, nil }
+	client.HTTPClient.
+		AddContentDecompresser("UTF-8", noopDecompresser).
+		AddContentDecompresser("utf-8", noopDecompresser)
 
 	// Initial authentication
 	if err := client.refreshToken(context.Background()); err != nil {


### PR DESCRIPTION
## Summary

Resolves #81. Registers a no-op `ContentDecompresser` keyed on `UTF-8` so Resty v3 stops bailing with `resty: content decoder not found` when SailPoint's edge returns the (non-standard) `Content-Encoding: UTF-8` header on 4xx responses. The JSON error body now reaches the per-resource error formatters, surfacing the real SailPoint message (`detailCode` + human-readable `text`) to users.

## Root cause (network trace)

Confirmed on `PATCH /v2025/identity-profiles/{id}` returning 400:

```
HTTP/1.1 400 Bad Request
Content-Length: 347
Content-Encoding: UTF-8
Content-Type: application/json;charset=utf-8
Server: cloudflare

{"detailCode":"400.1.3 Illegal value", "messages":[{"text":"Illegal value ..."}], ...}
```

`Content-Length: 347` matches the visible JSON body byte-for-byte → response is **not actually compressed**, the header is bogus (UTF-8 is a charset, not an encoding). Resty v3 (`response.go:280-295`) looks up the decompresser for `"UTF-8"`, doesn't find one, and returns `ErrContentDecompresserNotFound` before the body can be read.

## Why the previous workaround (PR #82) was insufficient

PR #82 added `Accept-Encoding: identity` to ask the server not to compress. Cloudflare ignores this header for 4xx responses and emits `Content-Encoding: UTF-8` regardless, so the workaround had no effect on failing code paths (transform create with em-dash, identity profile PATCH, etc.). The header is preserved in this PR for its microbenefit on 2xx responses.

## Why no-op decompresser over a custom transport

Considered a `http.RoundTripper` that strips non-whitelisted `Content-Encoding` values. Chose the no-op decompresser instead because:

- The exact bogus value (`UTF-8`) is now confirmed by network trace — the surgical fix matches the symptom 1:1.
- 3 lines of code, no `net/http` plumbing.
- If SailPoint ever serves a legit `Content-Encoding: br`, we'd see `content decoder not found` again and add the proper Brotli decoder — preferable to silently corrupting bodies.
- Easier to `git blame` and explain.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] No existing unit tests under `internal/client/` to run
- [ ] Manual: re-run the failing `tofu apply` (PATCH identity-profile) — confirm the diagnostic now shows the SailPoint `Illegal value` message instead of `resty: content decoder not found`

## Release plan

This PR also bumps the version to **v2.4.2** (CHANGELOG + RELEASE_NOTES). Once merged, tag `v2.4.2` triggers `.github/workflows/release.yml` (GoReleaser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)