### PR TITLE
chore(deps): ignore terraform-plugin-docs minor/major bumps until Go bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
     directory: "/tools"
     schedule:
       interval: "daily"
+    ignore:
+      # terraform-plugin-docs 0.25.0 raised its minimum Go to 1.25.8, which
+      # exceeds our `go.mod` baseline (and the HashiCorp scaffolding template's
+      # baseline). `tools/go.mod` must stay <= the main `go.mod`, so we skip
+      # minor/major bumps of this package until we are ready to bump Go
+      # globally. Patch bumps within the current minor remain allowed.
+      - dependency-name: "github.com/hashicorp/terraform-plugin-docs"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` rule for `terraform-plugin-docs` (minor + major bumps only) in `tools/`. Patch bumps within the current minor (0.24.x) keep flowing.

## Why

`terraform-plugin-docs` 0.25.0 raised its minimum Go to **1.25.8**, while our `go.mod` baseline is **1.25.0**. The `setup-go` action in our CI reads the main `go.mod` and installs Go 1.25.0 with `GOTOOLCHAIN=local`, so `make generate` (which runs `cd tools && go generate`) blows up with:

```
go: go.mod requires go >= 1.25.8 (running go 1.25.0; GOTOOLCHAIN=local)
```

This is exactly the failure on PR #105.

## Why not bump Go?

Looked at the HashiCorp [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) template for guidance:

| Their file | Version |
|---|---|
| `go.mod` (main) | `go 1.25.5` |
| `tools/go.mod` | `go 1.24.0` |
| `terraform-plugin-docs` | `v0.24.0` |

So the convention is **`tools/go.mod` <= main `go.mod`**, and **HashiCorp themselves are not on tfplugindocs 0.25.0** — even their main `go.mod` (1.25.5) wouldn't satisfy 1.25.8. The 0.25.0 release is too aggressive on the Go floor for the current ecosystem; waiting is reasonable.

## What this changes

```yaml
- package-ecosystem: "gomod"
  directory: "/tools"
  schedule:
    interval: "daily"
+ ignore:
+   - dependency-name: "github.com/hashicorp/terraform-plugin-docs"
+     update-types: ["version-update:semver-minor", "version-update:semver-major"]
```

When we are ready to bump Go globally (probably aligned with what HashiCorp does next), we lift the ignore and accept tfplugindocs minor/major in the same wave.

## Closes

- #105 (the blocked Dependabot bump that triggered this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)