### PR TITLE
fix: cluster of "inconsistent result after apply" errors (Closes #101, #106, #107)

### DIFF
--- a/.github/RELEASE_NOTES_v2.4.3.md
+++ b/.github/RELEASE_NOTES_v2.4.3.md
@@ -1,0 +1,27 @@
+# Release v2.4.3 - Cluster of "inconsistent result after apply" fixes
+
+Patch release that resolves three independent "Provider produced inconsistent result after apply" errors. All three were variants of the same underlying issue: the SailPoint API normalizes or rewrites parts of the request server-side, and the provider's planned state diverged from what the API ultimately returned, so the Terraform framework rejected the apply.
+
+## Bug Fixes
+
+- **Lifecycle State**: `access_profile_ids = []` (explicit empty list) no longer fails the first apply. The API normalizes `[]` to `null` in its response; the provider now consistently projects that as an empty list. Closes #107.
+- **Launcher**: `owner.type = "IDENTITY"` is now normalized to `"USER"` at plan time, matching the silent server-side rewrite that was causing the apply rejection. Closes #106.
+- **Source**: changing `owner.id` (or `cluster.id`) on a `sailpoint_source` no longer fails with a stale `owner.name`/`cluster.name` mismatch. The provider now re-resolves these names through the API when the underlying id changes, while still keeping no-op plans clean (no spurious `(known after apply)`). Closes #101.
+
+## Notes for upgraders
+
+- All three fixes are state-shape changes that the framework will resolve transparently on the next plan/apply. No HCL changes required.
+- For Lifecycle State: writing `access_profile_ids = []`, omitting the attribute, and reading back from the API are now equivalent. State entries that previously stored `null` will be re-read as `[]` on the next refresh.
+- A new internal package `internal/common/planmodifiers` ships with two reusable plan modifiers used by these fixes — available for future resource implementations.
+
+## Follow-up
+
+The pattern fixed in #101 (server-resolved attribute pinned by `UseStateForUnknown` despite a sibling id change) likely affects other resources too (entitlement, identity_profile, segment, role, access_profile). A follow-up audit issue will be opened to track that systematically.
+
+## Full Changelog
+
+See [CHANGELOG.md](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/blob/main/CHANGELOG.md) for complete details.
+
+---
+
+**Questions or Issues?** Please open an issue on [GitHub](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.3] - 2026-04-27
+
+### Fixed
+
+- **Lifecycle State**: `access_profile_ids = []` no longer fails the first apply with "inconsistent result after apply". The SailPoint API normalizes an empty list to `null` in its response; the provider now re-projects that to an empty list and adds a `[]` schema default so writing `[]`, omitting the attribute, and reading back from the API are all equivalent. Closes #107.
+- **Launcher**: `owner.type = "IDENTITY"` is now normalized to `"USER"` at plan time. The SailPoint Launchers API silently rewrites `IDENTITY` to `USER` server-side; the previous behavior left the plan with `"IDENTITY"` and triggered "inconsistent result after apply" when the API echoed back `"USER"`. The launcher is the only resource with this server-side normalization — `sailpoint_workflow` accepts `IDENTITY` unchanged. Closes #106.
+- **Source**: `owner.name` and `cluster.name` are now re-resolved by the API when the user changes `owner.id` or `cluster.id`. The previous `UseStateForUnknown` plan modifier pinned the stale prior name into the plan and the framework rejected the apply with "inconsistent result after apply"; a new conditional plan modifier preserves the no-op-plan behavior while letting the API resolve fresh names when the underlying id changes. Closes #101.
+
+### Added
+
+- **Internal**: `internal/common/planmodifiers` package with two reusable plan modifiers (`NormalizeString` for server-side enum normalization, `UseStateForUnknownUnlessSiblingChanges` for server-resolved attributes derived from a sibling). Used by the fixes above; available for future resources.
+
 ## [2.4.2] - 2026-04-26
 
 ### Fixed

--- a/docs/resources/launcher.md
+++ b/docs/resources/launcher.md
@@ -40,7 +40,7 @@ Resource for SailPoint Launcher. Launchers are used to trigger workflows through
 Required:
 
 - `id` (String) The ID of the owner.
-- `type` (String) The type of the owner (e.g., `IDENTITY`).
+- `type` (String) The type of the owner. The SailPoint Launchers API stores this as `USER` regardless of what is submitted; `IDENTITY` is silently normalized to `USER` server-side. The provider applies the same normalization at plan time so `tofu apply` does not fail with `inconsistent result after apply`.
 
 Read-Only:
 

--- a/docs/resources/lifecycle_state.md
+++ b/docs/resources/lifecycle_state.md
@@ -25,7 +25,7 @@ Resource for SailPoint Lifecycle State. Lifecycle states define the different st
 ### Optional
 
 - `access_action_configuration` (Attributes) Access action configuration for the lifecycle state. Defaults to `remove_all_access_enabled = false`. Remove this block from your configuration to reset to defaults. (see [below for nested schema](#nestedatt--access_action_configuration))
-- `access_profile_ids` (List of String) List of access profile IDs associated with this lifecycle state.
+- `access_profile_ids` (List of String) List of access profile IDs associated with this lifecycle state. Defaults to an empty list. The SailPoint API normalizes an empty list to `null` server-side; the provider re-projects that to an empty list so `[]` and the omitted attribute behave identically and `tofu apply` does not fail with `inconsistent result after apply`.
 - `account_actions` (Attributes List) List of account actions to perform when an identity enters this lifecycle state. (see [below for nested schema](#nestedatt--account_actions))
 - `description` (String) The description of the lifecycle state.
 - `email_notification_option` (Attributes) Email notification configuration for the lifecycle state. Defaults to all notifications disabled with an empty email list. Remove this block from your configuration to reset to defaults. (see [below for nested schema](#nestedatt--email_notification_option))

--- a/internal/common/planmodifiers/normalize_string.go
+++ b/internal/common/planmodifiers/normalize_string.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package planmodifiers contains reusable plan modifiers for the SailPoint ISC
+// Terraform provider. These exist mainly to absorb server-side normalizations
+// at plan time so apply does not fail with "inconsistent result after apply".
+package planmodifiers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// NormalizeString returns a plan modifier that rewrites the planned value of a
+// string attribute when it matches one of the keys in `aliases`, replacing it
+// with the canonical value. Use this when the SailPoint API silently rewrites
+// an input value server-side: aligning the plan with the canonical form
+// prevents the framework from rejecting the apply with "inconsistent result
+// after apply" once the server echoes the rewritten value back.
+func NormalizeString(aliases map[string]string) planmodifier.String {
+	return normalizeStringModifier{aliases: aliases}
+}
+
+type normalizeStringModifier struct {
+	aliases map[string]string
+}
+
+func (m normalizeStringModifier) Description(_ context.Context) string {
+	return fmt.Sprintf("Normalizes alias values to their canonical form: %v", m.aliases)
+}
+
+func (m normalizeStringModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m normalizeStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+	if canonical, ok := m.aliases[req.PlanValue.ValueString()]; ok {
+		resp.PlanValue = types.StringValue(canonical)
+	}
+}

--- a/internal/common/planmodifiers/use_state_unless_sibling.go
+++ b/internal/common/planmodifiers/use_state_unless_sibling.go
@@ -1,0 +1,78 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package planmodifiers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// UseStateForUnknownUnlessSiblingChanges returns a plan modifier that copies
+// the prior state value into the plan when the planned value is unknown
+// (typical for `Computed` attributes), UNLESS a sibling attribute has changed
+// — in which case the planned value is left as unknown so the API can resolve
+// it on apply.
+//
+// Use this on a server-resolved attribute (e.g. `owner.name`) that is derived
+// from another, user-controlled attribute (e.g. `owner.id`). Plain
+// `UseStateForUnknown` would freeze the stale prior name into the plan even
+// when the id changes, and the framework would then reject the apply with
+// `inconsistent result after apply` once the API echoes back the new name.
+//
+// `siblingName` is interpreted relative to the *parent* of the attribute the
+// modifier is attached to. For example, attaching this to `owner.name` with
+// `siblingName = "id"` looks up `owner.id`.
+func UseStateForUnknownUnlessSiblingChanges(siblingName string) planmodifier.String {
+	return useStateForUnknownUnlessSiblingChangesModifier{siblingName: siblingName}
+}
+
+type useStateForUnknownUnlessSiblingChangesModifier struct {
+	siblingName string
+}
+
+func (m useStateForUnknownUnlessSiblingChangesModifier) Description(_ context.Context) string {
+	return fmt.Sprintf("Use prior state value when planned value is unknown, unless sibling attribute %q changes.", m.siblingName)
+}
+
+func (m useStateForUnknownUnlessSiblingChangesModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m useStateForUnknownUnlessSiblingChangesModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// On Create the prior state is null — leave the planned value unknown so
+	// the API can resolve it on apply.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Only act when the planned value is unknown (the typical Computed case).
+	// If the user has somehow set a concrete planned value, respect it.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	siblingPath := req.Path.ParentPath().AtName(m.siblingName)
+
+	var planSibling, stateSibling types.String
+	if d := req.Plan.GetAttribute(ctx, siblingPath, &planSibling); d.HasError() {
+		resp.Diagnostics.Append(d...)
+		return
+	}
+	if d := req.State.GetAttribute(ctx, siblingPath, &stateSibling); d.HasError() {
+		resp.Diagnostics.Append(d...)
+		return
+	}
+
+	// If the sibling has changed, leave the planned value unknown so the API
+	// resolves it on apply. Otherwise reuse the prior state to keep no-op
+	// plans clean.
+	if !planSibling.Equal(stateSibling) {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/internal/services/launcher/launcher_resource.go
+++ b/internal/services/launcher/launcher_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -98,8 +99,14 @@ func (r *launcherResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
-						MarkdownDescription: "The type of the owner (e.g., `IDENTITY`).",
-						Required:            true,
+						MarkdownDescription: "The type of the owner. The SailPoint Launchers API stores this as " +
+							"`USER` regardless of what is submitted; `IDENTITY` is silently normalized to `USER` " +
+							"server-side. The provider applies the same normalization at plan time so " +
+							"`tofu apply` does not fail with `inconsistent result after apply`.",
+						Required: true,
+						PlanModifiers: []planmodifier.String{
+							planmodifiers.NormalizeString(map[string]string{"IDENTITY": "USER"}),
+						},
 					},
 					"id": schema.StringAttribute{
 						MarkdownDescription: "The ID of the owner.",

--- a/internal/services/lifecycle_state/lifecycle_state_model.go
+++ b/internal/services/lifecycle_state/lifecycle_state_model.go
@@ -134,13 +134,17 @@ func (m *lifecycleStateModel) FromAPI(ctx context.Context, api client.LifecycleS
 		m.AccountActions = types.ListNull(types.ObjectType{AttrTypes: accountActionAttrTypes})
 	}
 
-	// Map AccessProfileIds
+	// Map AccessProfileIds. The SailPoint API normalizes an empty list to `null`
+	// in the response. We always re-project to an empty (non-null) list so the
+	// schema default `[]` is consistent with what `Read`/`Create`/`Update` write
+	// back to state — otherwise the framework rejects with `inconsistent result
+	// after apply` whenever the user wrote `access_profile_ids = []`. See #107.
 	if len(api.AccessProfileIds) > 0 {
 		accessProfileIdsList, d := types.ListValueFrom(ctx, types.StringType, api.AccessProfileIds)
 		diags.Append(d...)
 		m.AccessProfileIds = accessProfileIdsList
 	} else {
-		m.AccessProfileIds = types.ListNull(types.StringType)
+		m.AccessProfileIds = types.ListValueMust(types.StringType, []attr.Value{})
 	}
 
 	// Map AccessActionConfiguration

--- a/internal/services/lifecycle_state/lifecycle_state_resource.go
+++ b/internal/services/lifecycle_state/lifecycle_state_resource.go
@@ -199,9 +199,14 @@ func (r *lifecycleStateResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"access_profile_ids": schema.ListAttribute{
-				MarkdownDescription: "List of access profile IDs associated with this lifecycle state.",
-				Optional:            true,
-				ElementType:         types.StringType,
+				MarkdownDescription: "List of access profile IDs associated with this lifecycle state. " +
+					"Defaults to an empty list. The SailPoint API normalizes an empty list to `null` server-side; " +
+					"the provider re-projects that to an empty list so `[]` and the omitted attribute behave identically " +
+					"and `tofu apply` does not fail with `inconsistent result after apply`.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 			},
 			"access_action_configuration": schema.SingleNestedAttribute{
 				MarkdownDescription: "Access action configuration for the lifecycle state. " +

--- a/internal/services/source/source_resource.go
+++ b/internal/services/source/source_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -87,7 +88,7 @@ func (r *sourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						MarkdownDescription: "The name of the owner. Resolved by the server from the owner ID.",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 						},
 					},
 				},
@@ -108,7 +109,7 @@ func (r *sourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						MarkdownDescription: "The name of the cluster. Resolved by the server from the cluster ID.",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

Resolves three independent "Provider produced inconsistent result after apply" errors. All three are variants of the same underlying issue: the SailPoint API normalizes or rewrites parts of the request server-side, and the provider's planned state diverged from what the API ultimately returned, so the framework rejected the apply on the first run (a second apply silently resynced).

| Issue | Resource | Server-side mutation | Fix |
|---|---|---|---|
| #107 | `sailpoint_lifecycle_state` | `accessProfileIds: []` → `null` in response | Always project as empty list; schema default `[]` |
| #106 | `sailpoint_launcher` | `owner.type = "IDENTITY"` → `"USER"` server-side | New `NormalizeString` plan modifier wired on `owner.type` |
| #101 | `sailpoint_source` | `owner.name`/`cluster.name` re-resolved when `id` changes | New `UseStateForUnknownUnlessSiblingChanges` plan modifier on the name attributes |

## New internal package

`internal/common/planmodifiers/` with two reusable plan modifiers:

- `NormalizeString(map[string]string)` — rewrites planned values through an alias table. Use for server-side enum normalization.
- `UseStateForUnknownUnlessSiblingChanges(siblingName)` — copies prior state into the plan when the planned value is unknown, **unless** a sibling attribute has changed. Use for server-resolved attributes derived from a user-controlled sibling.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `make generate` — docs regenerated (launcher + lifecycle_state descriptions updated)
- [ ] Manual: re-run the failing applies from #101, #106, #107 — confirm the first apply now succeeds without "inconsistent result after apply"

## Follow-up

The fix in #101 may apply to other resources with the same `Computed + UseStateForUnknown` pattern on server-resolved name attributes (entitlement, identity_profile, segment, role, access_profile). A follow-up audit issue will track that systematically.

## Release plan

Bumps version to **v2.4.3** (CHANGELOG + release notes). Once merged, tag `v2.4.3` triggers the GoReleaser workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)