### PR TITLE
fix(workflow): ignore server-minted refIDs in sp:http steps (Closes #90)

### DIFF
--- a/.github/RELEASE_NOTES_v2.4.4.md
+++ b/.github/RELEASE_NOTES_v2.4.4.md
@@ -1,0 +1,43 @@
+# Release v2.4.4 - sp:http workflow steps no longer fail on first apply
+
+Patch release that resolves the long-standing "Provider produced inconsistent result after apply" error when creating a `sailpoint_workflow` containing `sp:http` steps with Storage Parameter authentication (OAuth, header, OAuth scopes).
+
+## Bug Fixes
+
+- **Workflow**: `sp:http` steps with Storage Parameter auth no longer fail the first apply with `inconsistent result after apply`. SailPoint mints fresh `refID` values for each Storage Parameter reference at workflow POST time, regardless of what the client sends. The provider now treats those `refID` paths as semantically equal across plan and state. Closes #90.
+
+## How it works
+
+A new internal type `workflowStepsType` extends `jsontypes.NormalizedType` with a `SemanticEquals` implementation that:
+
+1. Parses both JSON values
+2. For each step, reads its `actionId`
+3. Strips the action-specific minted paths from both sides before comparison
+4. Returns `true` if the remaining JSON is equal
+
+Initial coverage (matching the surface of the bug report):
+
+- `sp:http`: `attributes.param_oauth.refID`
+- `sp:http`: `attributes.param_header.refID`
+- `sp:http`: `attributes.param_oauth_scopes.refID`
+
+Whenever the provider masks a divergence, a `TF_LOG=debug` line is emitted so users can audit what is being hidden.
+
+## Notes for upgraders
+
+- No HCL changes required. After upgrading, an `apply` that previously failed with `inconsistent result after apply` on `definition.steps` will now succeed.
+- The `refID` you write in your HCL is **not** what gets stored — SailPoint mints its own value at create time. The provider does not surface this divergence in plan output anymore. To audit the actual stored `refID`, run `tofu show` or query the API directly.
+- A `refID` that does not point to a real Storage Parameter Service entry will still fail at workflow runtime. Typically you obtain a valid `refID` by configuring the auth via the Workflow Builder UI once and copying back the persisted value.
+
+## Limitations
+
+- The list of ignored paths is hardcoded by action id. If SailPoint starts minting a new field that is not in the list, you'll see `inconsistent result after apply` again — please open an issue with the diff between `was` and `now` so we can extend the list.
+- A user-level override (HCL attribute to extend the ignore list) is intentionally deferred to a future release. The framework wiring for it is non-trivial and the maintained list is expected to cover the common cases.
+
+## Full Changelog
+
+See [CHANGELOG.md](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/blob/main/CHANGELOG.md) for complete details.
+
+---
+
+**Questions or Issues?** Please open an issue on [GitHub](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.4] - 2026-04-27
+
+### Fixed
+
+- **Workflow**: creating a `sailpoint_workflow` whose `definition.steps` contains an `sp:http` step with Storage Parameter auth (`param_oauth`, `param_header`, `param_oauth_scopes`) no longer fails the first apply with "inconsistent result after apply". SailPoint mints a fresh `refID` for each Storage Parameter reference at workflow POST time regardless of what the client sends; the provider now considers those `refID` paths semantically equal across plan and state via a custom JSON type (`workflowStepsType`). A `TF_LOG=debug` line is emitted whenever a divergence is masked, so users can audit what the provider is hiding. Closes #90.
+
+### Added
+
+- **Internal**: `workflowStepsType`, a custom string type extending `jsontypes.NormalizedType` with a `SemanticEquals` implementation that ignores server-minted JSON paths grouped by step `actionId`. New minted fields can be added to `ignoredFieldsByActionID` as they are discovered upstream.
+
 ## [2.4.3] - 2026-04-27
 
 ### Fixed

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -60,6 +60,8 @@ Required:
 
 ~> **Note:** When configuring steps that use secrets (e.g., OAuth client secrets for `sp:http` actions), set the secret value through the SailPoint UI first, then copy the resulting vault reference (e.g., `$.secrets.<uid>`) into your Terraform configuration to prevent drift.
 
+~> **Server-minted fields:** SailPoint mints fresh values for some fields at workflow creation regardless of what the client sends — currently `param_oauth.refID`, `param_header.refID`, and `param_oauth_scopes.refID` inside `sp:http` step `attributes`. The provider treats those paths as semantically equal across plan and state so `tofu apply` succeeds and no drift is reported. You can write any UUID for those fields (or omit them and SailPoint will mint one on create), but a `refID` that does not point to a real Storage Parameter Service entry will fail at workflow runtime — typically you obtain a valid `refID` by configuring auth via the Workflow Builder UI once and copying back the persisted value.
+
 
 <a id="nestedatt--creator"></a>
 ### Nested Schema for `creator`

--- a/internal/services/workflow/workflow_data_source.go
+++ b/internal/services/workflow/workflow_data_source.go
@@ -153,7 +153,7 @@ func (d *workflowDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 					"steps": schema.StringAttribute{
 						MarkdownDescription: "JSON object containing the workflow steps.",
 						Computed:            true,
-						CustomType:          jsontypes.NormalizedType{},
+						CustomType:          workflowStepsType{},
 					},
 				},
 			},

--- a/internal/services/workflow/workflow_model.go
+++ b/internal/services/workflow/workflow_model.go
@@ -17,7 +17,7 @@ import (
 // Attribute type definitions for nested objects.
 var definitionAttrTypes = map[string]attr.Type{
 	"start": types.StringType,
-	"steps": jsontypes.NormalizedType{},
+	"steps": workflowStepsType{},
 }
 
 // workflowModel represents the Terraform model for a SailPoint Workflow.

--- a/internal/services/workflow/workflow_resource.go
+++ b/internal/services/workflow/workflow_resource.go
@@ -177,9 +177,17 @@ func (r *workflowResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						MarkdownDescription: "JSON object containing the workflow steps. Each key is a step name and the value defines the step configuration including action type, attributes, and flow control.\n\n" +
 							"~> **Note:** When configuring steps that use secrets (e.g., OAuth client secrets for `sp:http` actions), " +
 							"set the secret value through the SailPoint UI first, then copy the resulting vault reference " +
-							"(e.g., `$.secrets.<uid>`) into your Terraform configuration to prevent drift.",
+							"(e.g., `$.secrets.<uid>`) into your Terraform configuration to prevent drift.\n\n" +
+							"~> **Server-minted fields:** SailPoint mints fresh values for some fields at workflow creation " +
+							"regardless of what the client sends — currently `param_oauth.refID`, `param_header.refID`, and " +
+							"`param_oauth_scopes.refID` inside `sp:http` step `attributes`. The provider treats those paths " +
+							"as semantically equal across plan and state so `tofu apply` succeeds and no drift is reported. " +
+							"You can write any UUID for those fields (or omit them and SailPoint will mint one on create), but " +
+							"a `refID` that does not point to a real Storage Parameter Service entry will fail at workflow " +
+							"runtime — typically you obtain a valid `refID` by configuring auth via the Workflow Builder UI " +
+							"once and copying back the persisted value.",
 						Required:   true,
-						CustomType: jsontypes.NormalizedType{},
+						CustomType: workflowStepsType{},
 					},
 				},
 			},

--- a/internal/services/workflow/workflow_steps_type.go
+++ b/internal/services/workflow/workflow_steps_type.go
@@ -1,0 +1,198 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// ignoredFieldsByActionID lists the JSON paths inside each step's `attributes`
+// block that SailPoint mints/normalizes server-side and that the provider must
+// not treat as a divergence between plan and state. Without this list, a
+// `tofu apply` that creates or updates a workflow with one of these step types
+// fails with `Provider produced inconsistent result after apply` on the very
+// first apply (the second apply silently resyncs because the state then
+// matches the API).
+//
+// Paths use dotted notation, relative to the step's value (i.e. *not* including
+// the step name). The walker traverses nested objects only — no array support
+// for now since none of the known minted fields live inside arrays.
+//
+// Add a new entry whenever a SailPoint action surface starts minting another
+// field. Keep entries grouped by SailPoint action id so the source of truth
+// stays readable.
+var ignoredFieldsByActionID = map[string][]string{
+	// `sp:http` Storage Parameter Service refs: SailPoint mints a fresh refID
+	// at workflow POST time regardless of what the client sends. paramID and
+	// other auth-related metadata are preserved as submitted.
+	"sp:http": {
+		"attributes.param_oauth.refID",
+		"attributes.param_header.refID",
+		"attributes.param_oauth_scopes.refID",
+	},
+}
+
+// workflowStepsType extends jsontypes.NormalizedType with a SemanticEquals
+// implementation that ignores server-minted fields per action id. See
+// `ignoredFieldsByActionID` for the maintained allow-list and #90 for the
+// underlying SailPoint behavior.
+type workflowStepsType struct {
+	jsontypes.NormalizedType
+}
+
+func (t workflowStepsType) String() string {
+	return "workflow.workflowStepsType"
+}
+
+func (t workflowStepsType) ValueType(_ context.Context) attr.Value {
+	return workflowStepsValue{}
+}
+
+func (t workflowStepsType) Equal(o attr.Type) bool {
+	other, ok := o.(workflowStepsType)
+	if !ok {
+		return false
+	}
+	return t.NormalizedType.Equal(other.NormalizedType)
+}
+
+func (t workflowStepsType) ValueFromString(_ context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return workflowStepsValue{Normalized: jsontypes.Normalized{StringValue: in}}, nil
+}
+
+func (t workflowStepsType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.NormalizedType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	normalized, ok := attrValue.(jsontypes.Normalized)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type from NormalizedType.ValueFromTerraform: %T", attrValue)
+	}
+	return workflowStepsValue{Normalized: normalized}, nil
+}
+
+// workflowStepsValue wraps jsontypes.Normalized with the extended
+// SemanticEquals logic.
+type workflowStepsValue struct {
+	jsontypes.Normalized
+}
+
+func (v workflowStepsValue) Type(_ context.Context) attr.Type {
+	return workflowStepsType{}
+}
+
+func (v workflowStepsValue) Equal(o attr.Value) bool {
+	other, ok := o.(workflowStepsValue)
+	if !ok {
+		return false
+	}
+	return v.Normalized.Equal(other.Normalized)
+}
+
+// StringSemanticEquals returns true when the two JSON strings are equal after
+// stripping the server-minted fields documented in `ignoredFieldsByActionID`.
+// A debug-level log line is emitted on every ignored divergence so a user
+// running with `TF_LOG=debug` can audit what the provider is masking.
+func (v workflowStepsValue) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var newStr string
+	switch nv := newValuable.(type) {
+	case workflowStepsValue:
+		newStr = nv.ValueString()
+	case jsontypes.Normalized:
+		newStr = nv.ValueString()
+	default:
+		diags.AddError(
+			"Semantic Equality Check Error",
+			fmt.Sprintf("workflowStepsValue.StringSemanticEquals received an unexpected value type %T; please report this to the provider developers.", newValuable),
+		)
+		return false, diags
+	}
+
+	oldStripped, oldOriginal, err := stripIgnoredFields(v.ValueString())
+	if err != nil {
+		diags.AddError("Semantic Equality Check Error", "Failed to parse prior JSON: "+err.Error())
+		return false, diags
+	}
+	newStripped, newOriginal, err := stripIgnoredFields(newStr)
+	if err != nil {
+		diags.AddError("Semantic Equality Check Error", "Failed to parse new JSON: "+err.Error())
+		return false, diags
+	}
+
+	if !reflect.DeepEqual(oldStripped, newStripped) {
+		return false, diags
+	}
+
+	// Equal post-strip. If the original JSONs differ, we masked something —
+	// log the masked paths for traceability.
+	if !reflect.DeepEqual(oldOriginal, newOriginal) {
+		tflog.Debug(ctx, "workflow_steps: semantic-equal after stripping server-minted fields", map[string]any{
+			"ignored_paths_per_action_id": ignoredFieldsByActionID,
+		})
+	}
+
+	return true, diags
+}
+
+// stripIgnoredFields parses the JSON and removes, in-place, the fields listed
+// in `ignoredFieldsByActionID` for every step that matches a known action id.
+// Returns the stripped representation (used for comparison) AND the original
+// parsed representation (used to detect whether anything was actually masked).
+func stripIgnoredFields(jsonStr string) (stripped, original map[string]any, err error) {
+	if err := json.Unmarshal([]byte(jsonStr), &stripped); err != nil {
+		return nil, nil, err
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &original); err != nil {
+		return nil, nil, err
+	}
+
+	for stepName, raw := range stripped {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		actionID, _ := step["actionId"].(string)
+		paths, has := ignoredFieldsByActionID[actionID]
+		if !has {
+			continue
+		}
+		for _, p := range paths {
+			deletePath(step, strings.Split(p, "."))
+		}
+		_ = stepName
+	}
+
+	return stripped, original, nil
+}
+
+// deletePath removes the leaf key reached by walking `parts` through nested
+// objects in `node`. Missing keys along the way are silently ignored.
+func deletePath(node map[string]any, parts []string) {
+	if len(parts) == 0 {
+		return
+	}
+	if len(parts) == 1 {
+		delete(node, parts[0])
+		return
+	}
+	next, ok := node[parts[0]].(map[string]any)
+	if !ok {
+		return
+	}
+	deletePath(next, parts[1:])
+}

--- a/internal/services/workflow/workflow_steps_type_test.go
+++ b/internal/services/workflow/workflow_steps_type_test.go
@@ -1,0 +1,147 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// stepsValue is a small helper to keep the test cases compact.
+func stepsValue(s string) workflowStepsValue {
+	return workflowStepsValue{Normalized: jsontypes.NewNormalizedValue(s)}
+}
+
+func TestWorkflowStepsValue_StringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		old, new string
+		want     bool
+		wantErr  bool
+	}{
+		"identical": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"url":"https://example.com"}}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"url":"https://example.com"}}}`,
+			want: true,
+		},
+		"whitespace and key order differences": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"url":"https://example.com"}}}`,
+			new:  "{\n  \"step1\": {\n    \"attributes\": {\"url\": \"https://example.com\"},\n    \"actionId\": \"sp:http\"\n  }\n}",
+			want: true,
+		},
+		"sp:http param_oauth.refID differs only": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"old-uuid","paramType":"1.4"}}}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"new-uuid","paramType":"1.4"}}}}`,
+			want: true,
+		},
+		"sp:http param_header.refID differs only": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"param_header":{"refID":"old","paramType":"1.3"}}}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"param_header":{"refID":"new","paramType":"1.3"}}}}`,
+			want: true,
+		},
+		"sp:http param_oauth_scopes.refID differs only": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth_scopes":{"refID":"old","paramType":"3.1"}}}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth_scopes":{"refID":"new","paramType":"3.1"}}}}`,
+			want: true,
+		},
+		"sp:http with all three minted refIDs differing": {
+			old: `{"step1":{"actionId":"sp:http","attributes":{` +
+				`"param_oauth":{"refID":"o1","paramType":"1.4"},` +
+				`"param_header":{"refID":"h1","paramType":"1.3"},` +
+				`"param_oauth_scopes":{"refID":"s1","paramType":"3.1"}` +
+				`}}}`,
+			new: `{"step1":{"actionId":"sp:http","attributes":{` +
+				`"param_oauth":{"refID":"o2","paramType":"1.4"},` +
+				`"param_header":{"refID":"h2","paramType":"1.3"},` +
+				`"param_oauth_scopes":{"refID":"s2","paramType":"3.1"}` +
+				`}}}`,
+			want: true,
+		},
+		"sp:http refID differs AND another field differs": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"url":"https://a","param_oauth":{"refID":"old"}}}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"url":"https://b","param_oauth":{"refID":"new"}}}}`,
+			want: false,
+		},
+		"sp:http paramID differs (not in ignore list)": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"x","paramID":"old"}}}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"x","paramID":"new"}}}}`,
+			want: false,
+		},
+		"unknown actionId — refID diff is NOT ignored": {
+			old:  `{"step1":{"actionId":"sp:custom","attributes":{"param_oauth":{"refID":"old"}}}}`,
+			new:  `{"step1":{"actionId":"sp:custom","attributes":{"param_oauth":{"refID":"new"}}}}`,
+			want: false,
+		},
+		"missing actionId on step — refID diff is NOT ignored": {
+			old:  `{"step1":{"attributes":{"param_oauth":{"refID":"old"}}}}`,
+			new:  `{"step1":{"attributes":{"param_oauth":{"refID":"new"}}}}`,
+			want: false,
+		},
+		"step renamed (key changes) — not equal": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{}}}`,
+			new:  `{"renamed":{"actionId":"sp:http","attributes":{}}}`,
+			want: false,
+		},
+		"sibling step (non sp:http) differs — not equal": {
+			old:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"x"}}},"endOk":{"type":"success","displayName":"End A"}}`,
+			new:  `{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"y"}}},"endOk":{"type":"success","displayName":"End B"}}`,
+			want: false,
+		},
+		"step with no attributes block": {
+			old:  `{"endOk":{"type":"success","displayName":"End"}}`,
+			new:  `{"endOk":{"type":"success","displayName":"End"}}`,
+			want: true,
+		},
+		"invalid JSON on old side": {
+			old:     `{not json`,
+			new:     `{"step1":{}}`,
+			wantErr: true,
+		},
+		"invalid JSON on new side": {
+			old:     `{"step1":{}}`,
+			new:     `{not json`,
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			old := stepsValue(tc.old)
+			got, diags := old.StringSemanticEquals(context.Background(), stepsValue(tc.new))
+
+			if tc.wantErr {
+				if !diags.HasError() {
+					t.Fatalf("expected diagnostics error, got none")
+				}
+				return
+			}
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if got != tc.want {
+				t.Errorf("StringSemanticEquals = %v, want %v\nold=%s\nnew=%s", got, tc.want, tc.old, tc.new)
+			}
+		})
+	}
+}
+
+func TestWorkflowStepsValue_StringSemanticEquals_AcceptsBareNormalized(t *testing.T) {
+	t.Parallel()
+	// The framework may pass a plain jsontypes.Normalized (not wrapped in our
+	// custom value) when comparing. The implementation must accept both.
+	old := stepsValue(`{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"a"}}}}`)
+	bareNew := jsontypes.NewNormalizedValue(`{"step1":{"actionId":"sp:http","attributes":{"param_oauth":{"refID":"b"}}}}`)
+
+	got, diags := old.StringSemanticEquals(context.Background(), bareNew)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !got {
+		t.Errorf("expected semantic equal across our value and bare jsontypes.Normalized, got false")
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #90: creating a `sailpoint_workflow` whose `definition.steps` contains an `sp:http` step with Storage Parameter auth fails the first apply with `Provider produced inconsistent result after apply`. Root cause confirmed in the issue thread: SailPoint mints a fresh `refID` for each Storage Parameter reference at workflow POST time, regardless of what the client sends. The provider faithfully echoed back the minted `refID` in state, so the framework saw a divergence between the user's HCL value and the server-resolved value.

## Approach: Strategy R-pragmatic (per discussion)

| Strategy | In this PR? | Notes |
|---|---|---|
| 2 — paths grouped by `actionId` (`map[string][]string`) | ✅ | Initial coverage: `sp:http` × 3 paths |
| 6 — `tflog.Debug` when a divergence is masked | ✅ | Emits the action-id → paths map for traceability |
| 3 — user-level override (HCL attribute to extend the list) | ❌ | Deferred. Framework wiring is non-trivial (custom type's `SemanticEquals` cannot read sibling attributes); maintained list is expected to cover the common cases. |

## What's added

- `internal/services/workflow/workflow_steps_type.go` (~190 lines): custom string type extending `jsontypes.NormalizedType`. Implements `StringSemanticEquals` that parses both sides, walks each step, looks up minted paths by `actionId` in `ignoredFieldsByActionID`, strips them from both sides, and compares the remainder.
- `internal/services/workflow/workflow_steps_type_test.go` (~140 lines): 15 unit tests covering identical/whitespace/each minted path/all-three-together/divergence-outside-ignore-list/unknown actionId/missing actionId/step rename/sibling step diff/no-attributes step/invalid JSON/cross-type comparison with bare `jsontypes.Normalized`.

Wired in 3 places where `jsontypes.NormalizedType{}` was previously used for `definition.steps`:
- `workflow_resource.go` (resource schema)
- `workflow_data_source.go` (data source schema)
- `workflow_model.go` (`definitionAttrTypes` map)

## Behavior

### First apply (Create)
1. TF sends user-provided `refID` in payload
2. SailPoint mints its own `refID`, stores, returns in response
3. Provider state stores the response (truth)
4. Framework compares plan ↔ state via `SemanticEquals` → ignores minted `refID` → equal → **no error**

### Subsequent plans (Read)
1. Read pulls workflow from SailPoint, state stores minted `refID`
2. User HCL still has their original `refID`
3. Plan compares config ↔ state via `SemanticEquals` → equal → **no drift**

### `TF_LOG=debug`
Whenever a divergence is masked, emits:
```
DEBUG workflow_steps: semantic-equal after stripping server-minted fields
  ignored_paths_per_action_id=map[sp:http:[attributes.param_oauth.refID attributes.param_header.refID attributes.param_oauth_scopes.refID]]
```

## Test plan

- [x] `go test ./internal/services/workflow/... -v -run TestWorkflowStepsValue` — 15/15 pass
- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `make generate` — workflow docs regenerated
- [ ] Manual: re-run the failing apply from #90 — confirm it now succeeds and that subsequent plans show no drift
- [ ] Manual: re-run with `TF_LOG=debug` and verify the masked-paths log line appears

## Release plan

Bumps version to **v2.4.4** (CHANGELOG + release notes). Once merged, tag `v2.4.4` triggers GoReleaser.

## Limitations (documented in release notes)

1. The list of ignored paths is hardcoded by `actionId`. If SailPoint starts minting a new field that is not in the list, users will see `inconsistent result after apply` again — they should open an issue with the diff between `was` and `now`.
2. The `refID` written in HCL is not what gets stored — SailPoint mints its own. To audit the actual stored value, `tofu show` or query the API directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)