### PR TITLE
feat(source): add ignore_attributes_paths to preserve server-managed nested fields

### DIFF
--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -29,6 +29,16 @@ Work on the feature branch:
 - Test changes if possible
 - Ensure code compiles
 
+### 2.5 Pre-commit validation (mandatory)
+Before staging the commit, run locally what CI will run:
+```bash
+make lint      # golangci-lint — strict config: forcetypeassert, gofmt, errcheck, ...
+make generate  # tfplugindocs — regenerates docs/ from schema descriptions
+```
+- Both must exit clean. If `make generate` produces a diff under `docs/`, stage it in the same commit (otherwise the `generate` CI job fails on "Unexpected difference").
+- New test files: type assertions must use the `, ok :=` form (`forcetypeassert` is enabled) — provide `must*` helpers if needed, don't write bare `x.(T)`.
+- This step is non-negotiable for any branch that will be pushed to a PR — CI runs the same commands and a fail here blocks the PR.
+
 ### 3. Commit at the End
 Once all changes are complete and verified:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,19 @@ This is a Terraform provider for SailPoint Identity Security Cloud (ISC) built u
 ### Default Target
 - `make` - Runs fmt, lint, install, and generate
 
+## Pre-commit validation (mandatory)
+
+Before staging any commit on a branch that will be pushed to a PR, run:
+
+```bash
+make lint      # golangci-lint — strict config: forcetypeassert, gofmt, errcheck, ...
+make generate  # tfplugindocs — regenerates docs/ from schema descriptions
+```
+
+- Both must exit clean. If `make generate` produces a diff under `docs/`, stage it in the same commit — otherwise the `generate` CI job fails on *"Unexpected difference in directories after code generation"*.
+- New `_test.go` files: type assertions MUST use the `, ok :=` form (the `forcetypeassert` linter is enabled). For repeated assertions in tests, define small `must*` helpers with `t.Helper()` rather than scattering bare `x.(T)`.
+- CI runs these exact commands; a local fail here is a guaranteed PR fail.
+
 ## Architecture
 
 ### Directory Structure

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -33,6 +33,7 @@ Resource for SailPoint Source. Sources represent managed systems (e.g., Active D
 - `delete_threshold` (Number) The percentage threshold for skipping the delete phase (0-100).
 - `description` (String) The description of the source.
 - `features` (Set of String) The list of features enabled for the source (e.g., `PROVISIONING`, `SYNC_PROVISIONING`, `AUTHENTICATE`).
+- `ignore_attributes_paths` (List of String) A list of JSONPath expressions identifying fields inside `connector_attributes` that should be preserved from the server state rather than overwritten on each apply. Use this to protect server-managed sensitive fields (e.g. passwords) nested inside arrays that you declare in `connector_attributes`. Supported syntax: `$.key`, `$.key.nested`, `$.key[N].field` (specific index), `$.key[*].field` (all elements). Example: `["$.domainSettings[*].password", "$.forestSettings[*].servicePassword"]`.
 - `provision_as_csv` (Boolean) If `true`, configures the source as a Delimited File (CSV) source during creation. This is a create-only parameter and cannot be changed after creation.
 - `type` (String) The type of system being managed. Cannot be changed after creation.
 

--- a/internal/common/jsonpath/jsonpath.go
+++ b/internal/common/jsonpath/jsonpath.go
@@ -1,0 +1,162 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package jsonpath implements a minimal subset of JSONPath for preserving
+// server-managed fields in connector_attributes arrays.
+//
+// Supported syntax:
+//
+//	$.key
+//	$.key.nested
+//	$.key[N].field   (N is a non-negative integer index)
+//	$.key[*].field   (wildcard: all array elements)
+package jsonpath
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type segKind int
+
+const (
+	segKey      segKind = iota
+	segWildcard         // [*]
+	segIndex            // [N]
+)
+
+type segment struct {
+	kind segKind
+	key  string
+	idx  int
+}
+
+// Parse parses a minimal JSONPath expression into segments.
+// Returns an error for any syntax not in the supported subset.
+func Parse(path string) ([]segment, error) {
+	if !strings.HasPrefix(path, "$") {
+		return nil, fmt.Errorf("path must start with '$', got: %q", path)
+	}
+	rest := path[1:]
+	var segs []segment
+
+	for len(rest) > 0 {
+		switch rest[0] {
+		case '.':
+			rest = rest[1:]
+			end := strings.IndexAny(rest, ".[")
+			var key string
+			if end < 0 {
+				key, rest = rest, ""
+			} else {
+				key, rest = rest[:end], rest[end:]
+			}
+			if key == "" {
+				return nil, fmt.Errorf("empty key segment in path: %q", path)
+			}
+			segs = append(segs, segment{kind: segKey, key: key})
+
+		case '[':
+			end := strings.Index(rest, "]")
+			if end < 0 {
+				return nil, fmt.Errorf("unclosed '[' in path: %q", path)
+			}
+			inner := rest[1:end]
+			rest = rest[end+1:]
+			if inner == "*" {
+				segs = append(segs, segment{kind: segWildcard})
+			} else {
+				idx, err := strconv.Atoi(inner)
+				if err != nil || idx < 0 {
+					return nil, fmt.Errorf("invalid index %q in path: %q (expected non-negative integer or *)", inner, path)
+				}
+				segs = append(segs, segment{kind: segIndex, idx: idx})
+			}
+
+		default:
+			return nil, fmt.Errorf("unexpected character %q in path: %q", string(rest[0]), path)
+		}
+	}
+
+	if len(segs) == 0 {
+		return nil, fmt.Errorf("path %q has no segments", path)
+	}
+	return segs, nil
+}
+
+// Validate returns an error if path is not a valid minimal JSONPath expression.
+func Validate(path string) error {
+	_, err := Parse(path)
+	return err
+}
+
+// PreservePaths re-injects values from serverAttrs into merged at each path.
+// Paths that don't exist in serverAttrs are silently skipped.
+// Returns an error only if a path cannot be parsed.
+func PreservePaths(merged, serverAttrs map[string]interface{}, paths []string) error {
+	for _, path := range paths {
+		segs, err := Parse(path)
+		if err != nil {
+			return fmt.Errorf("preserve paths: %w", err)
+		}
+		preserveNode(merged, serverAttrs, segs)
+	}
+	return nil
+}
+
+// preserveNode walks merged and server in lock-step following segs,
+// and at the leaf key copies the server value into merged.
+func preserveNode(mergedNode, serverNode interface{}, segs []segment) {
+	if len(segs) == 0 {
+		return
+	}
+
+	seg := segs[0]
+	rest := segs[1:]
+
+	switch seg.kind {
+	case segKey:
+		mergedMap, ok1 := mergedNode.(map[string]interface{})
+		serverMap, ok2 := serverNode.(map[string]interface{})
+		if !ok1 || !ok2 {
+			return
+		}
+		serverVal, exists := serverMap[seg.key]
+		if !exists {
+			return
+		}
+		if len(rest) == 0 {
+			// Leaf: copy server value into merged map.
+			mergedMap[seg.key] = serverVal
+			return
+		}
+		mergedVal := mergedMap[seg.key]
+		preserveNode(mergedVal, serverVal, rest)
+
+	case segWildcard:
+		mergedArr, ok1 := mergedNode.([]interface{})
+		serverArr, ok2 := serverNode.([]interface{})
+		if !ok1 || !ok2 {
+			return
+		}
+		for i := range mergedArr {
+			if i >= len(serverArr) {
+				break
+			}
+			preserveNode(mergedArr[i], serverArr[i], rest)
+		}
+
+	case segIndex:
+		mergedArr, ok1 := mergedNode.([]interface{})
+		serverArr, ok2 := serverNode.([]interface{})
+		if !ok1 || !ok2 {
+			return
+		}
+		i := seg.idx
+		if i >= len(mergedArr) || i >= len(serverArr) {
+			return
+		}
+		preserveNode(mergedArr[i], serverArr[i], rest)
+	}
+}

--- a/internal/common/jsonpath/jsonpath_test.go
+++ b/internal/common/jsonpath/jsonpath_test.go
@@ -1,0 +1,298 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package jsonpath
+
+import (
+	"testing"
+)
+
+func TestParse_valid(t *testing.T) {
+	cases := []struct {
+		path     string
+		wantKinds []segKind
+		wantKeys  []string
+		wantIdxs  []int
+	}{
+		{
+			path:      "$.foo",
+			wantKinds: []segKind{segKey},
+			wantKeys:  []string{"foo"},
+			wantIdxs:  []int{0},
+		},
+		{
+			path:      "$.foo.bar",
+			wantKinds: []segKind{segKey, segKey},
+			wantKeys:  []string{"foo", "bar"},
+			wantIdxs:  []int{0, 0},
+		},
+		{
+			path:      "$.foo[*].bar",
+			wantKinds: []segKind{segKey, segWildcard, segKey},
+			wantKeys:  []string{"foo", "", "bar"},
+			wantIdxs:  []int{0, -1, 0},
+		},
+		{
+			path:      "$.foo[0].bar",
+			wantKinds: []segKind{segKey, segIndex, segKey},
+			wantKeys:  []string{"foo", "", "bar"},
+			wantIdxs:  []int{0, 0, 0},
+		},
+		{
+			path:      "$.foo[2].bar",
+			wantKinds: []segKind{segKey, segIndex, segKey},
+			wantKeys:  []string{"foo", "", "bar"},
+			wantIdxs:  []int{0, 2, 0},
+		},
+		{
+			path:      "$.a.b.c",
+			wantKinds: []segKind{segKey, segKey, segKey},
+			wantKeys:  []string{"a", "b", "c"},
+			wantIdxs:  []int{0, 0, 0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			segs, err := Parse(tc.path)
+			if err != nil {
+				t.Fatalf("Parse(%q) unexpected error: %v", tc.path, err)
+			}
+			if len(segs) != len(tc.wantKinds) {
+				t.Fatalf("Parse(%q) got %d segments, want %d", tc.path, len(segs), len(tc.wantKinds))
+			}
+			for i, seg := range segs {
+				if seg.kind != tc.wantKinds[i] {
+					t.Errorf("segment[%d].kind = %v, want %v", i, seg.kind, tc.wantKinds[i])
+				}
+				if tc.wantKinds[i] == segKey && seg.key != tc.wantKeys[i] {
+					t.Errorf("segment[%d].key = %q, want %q", i, seg.key, tc.wantKeys[i])
+				}
+				if tc.wantKinds[i] == segIndex && seg.idx != tc.wantIdxs[i] {
+					t.Errorf("segment[%d].idx = %d, want %d", i, seg.idx, tc.wantIdxs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParse_invalid(t *testing.T) {
+	cases := []struct {
+		path string
+	}{
+		{path: "foo"},            // no leading $
+		{path: "$"},              // no segments
+		{path: "$."},             // empty key
+		{path: "$.foo["},         // unclosed bracket
+		{path: "$.foo[-1].bar"},  // negative index
+		{path: "$.foo[abc].bar"}, // non-integer index
+		{path: "$!foo"},          // unexpected char
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			_, err := Parse(tc.path)
+			if err == nil {
+				t.Errorf("Parse(%q) expected error, got nil", tc.path)
+			}
+		})
+	}
+}
+
+func TestPreservePaths_topLevelField(t *testing.T) {
+	merged := map[string]interface{}{
+		"host": "ldap.example.com",
+	}
+	server := map[string]interface{}{
+		"host":     "ldap.example.com",
+		"password": "secret",
+	}
+	if err := PreservePaths(merged, server, []string{"$.password"}); err != nil {
+		t.Fatal(err)
+	}
+	if merged["password"] != "secret" {
+		t.Errorf("merged[password] = %v, want %q", merged["password"], "secret")
+	}
+}
+
+func TestPreservePaths_wildcardArrayField(t *testing.T) {
+	merged := map[string]interface{}{
+		"domainSettings": []interface{}{
+			map[string]interface{}{
+				"forestName": "corp.example.com",
+				"user":       "svc-account",
+			},
+			map[string]interface{}{
+				"forestName": "other.example.com",
+				"user":       "svc-other",
+			},
+		},
+	}
+	server := map[string]interface{}{
+		"domainSettings": []interface{}{
+			map[string]interface{}{
+				"forestName": "corp.example.com",
+				"user":       "svc-account",
+				"password":   "pass1",
+			},
+			map[string]interface{}{
+				"forestName": "other.example.com",
+				"user":       "svc-other",
+				"password":   "pass2",
+			},
+		},
+	}
+
+	if err := PreservePaths(merged, server, []string{"$.domainSettings[*].password"}); err != nil {
+		t.Fatal(err)
+	}
+
+	arr := merged["domainSettings"].([]interface{})
+	if v := arr[0].(map[string]interface{})["password"]; v != "pass1" {
+		t.Errorf("element[0].password = %v, want %q", v, "pass1")
+	}
+	if v := arr[1].(map[string]interface{})["password"]; v != "pass2" {
+		t.Errorf("element[1].password = %v, want %q", v, "pass2")
+	}
+}
+
+func TestPreservePaths_specificIndexField(t *testing.T) {
+	merged := map[string]interface{}{
+		"domainSettings": []interface{}{
+			map[string]interface{}{"forestName": "a"},
+			map[string]interface{}{"forestName": "b"},
+		},
+	}
+	server := map[string]interface{}{
+		"domainSettings": []interface{}{
+			map[string]interface{}{"forestName": "a", "password": "secret0"},
+			map[string]interface{}{"forestName": "b", "password": "secret1"},
+		},
+	}
+
+	if err := PreservePaths(merged, server, []string{"$.domainSettings[1].password"}); err != nil {
+		t.Fatal(err)
+	}
+
+	arr := merged["domainSettings"].([]interface{})
+	if _, ok := arr[0].(map[string]interface{})["password"]; ok {
+		t.Error("element[0].password should not be set")
+	}
+	if v := arr[1].(map[string]interface{})["password"]; v != "secret1" {
+		t.Errorf("element[1].password = %v, want %q", v, "secret1")
+	}
+}
+
+func TestPreservePaths_serverMissingKey(t *testing.T) {
+	merged := map[string]interface{}{
+		"foo": "bar",
+	}
+	server := map[string]interface{}{
+		"foo": "bar",
+		// "password" absent from server
+	}
+	// Should silently skip; merged unchanged
+	if err := PreservePaths(merged, server, []string{"$.password"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := merged["password"]; ok {
+		t.Error("password should not be injected when absent from server")
+	}
+}
+
+func TestPreservePaths_mergedHasMoreElementsThanServer(t *testing.T) {
+	// User added a new element that doesn't exist on the server yet.
+	// Wildcard should only process indices present in both.
+	merged := map[string]interface{}{
+		"settings": []interface{}{
+			map[string]interface{}{"name": "existing"},
+			map[string]interface{}{"name": "new"},
+		},
+	}
+	server := map[string]interface{}{
+		"settings": []interface{}{
+			map[string]interface{}{"name": "existing", "token": "abc"},
+			// server only has 1 element
+		},
+	}
+
+	if err := PreservePaths(merged, server, []string{"$.settings[*].token"}); err != nil {
+		t.Fatal(err)
+	}
+
+	arr := merged["settings"].([]interface{})
+	if v := arr[0].(map[string]interface{})["token"]; v != "abc" {
+		t.Errorf("element[0].token = %v, want %q", v, "abc")
+	}
+	if _, ok := arr[1].(map[string]interface{})["token"]; ok {
+		t.Error("element[1].token should not be set (new element not in server)")
+	}
+}
+
+func TestPreservePaths_nestedObject(t *testing.T) {
+	merged := map[string]interface{}{
+		"connection": map[string]interface{}{
+			"host": "ldap.example.com",
+		},
+	}
+	server := map[string]interface{}{
+		"connection": map[string]interface{}{
+			"host":     "ldap.example.com",
+			"password": "secret",
+		},
+	}
+
+	if err := PreservePaths(merged, server, []string{"$.connection.password"}); err != nil {
+		t.Fatal(err)
+	}
+
+	conn := merged["connection"].(map[string]interface{})
+	if conn["password"] != "secret" {
+		t.Errorf("connection.password = %v, want %q", conn["password"], "secret")
+	}
+}
+
+func TestPreservePaths_invalidPath(t *testing.T) {
+	merged := map[string]interface{}{}
+	server := map[string]interface{}{}
+	err := PreservePaths(merged, server, []string{"invalid-path"})
+	if err == nil {
+		t.Error("expected error for invalid path")
+	}
+}
+
+func TestPreservePaths_multiplePaths(t *testing.T) {
+	merged := map[string]interface{}{
+		"domainSettings": []interface{}{
+			map[string]interface{}{"forestName": "corp"},
+		},
+		"forestSettings": []interface{}{
+			map[string]interface{}{"name": "forest1"},
+		},
+	}
+	server := map[string]interface{}{
+		"domainSettings": []interface{}{
+			map[string]interface{}{"forestName": "corp", "password": "pass1"},
+		},
+		"forestSettings": []interface{}{
+			map[string]interface{}{"name": "forest1", "servicePassword": "pass2"},
+		},
+	}
+
+	paths := []string{
+		"$.domainSettings[*].password",
+		"$.forestSettings[*].servicePassword",
+	}
+	if err := PreservePaths(merged, server, paths); err != nil {
+		t.Fatal(err)
+	}
+
+	domArr := merged["domainSettings"].([]interface{})
+	if v := domArr[0].(map[string]interface{})["password"]; v != "pass1" {
+		t.Errorf("domainSettings[0].password = %v, want %q", v, "pass1")
+	}
+	forArr := merged["forestSettings"].([]interface{})
+	if v := forArr[0].(map[string]interface{})["servicePassword"]; v != "pass2" {
+		t.Errorf("forestSettings[0].servicePassword = %v, want %q", v, "pass2")
+	}
+}

--- a/internal/common/jsonpath/jsonpath_test.go
+++ b/internal/common/jsonpath/jsonpath_test.go
@@ -7,9 +7,29 @@ import (
 	"testing"
 )
 
+// mustArray asserts that v is a []interface{} and returns it. Fails the test otherwise.
+func mustArray(t *testing.T, v interface{}, what string) []interface{} {
+	t.Helper()
+	arr, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("%s: expected []interface{}, got %T", what, v)
+	}
+	return arr
+}
+
+// mustObject asserts that v is a map[string]interface{} and returns it. Fails the test otherwise.
+func mustObject(t *testing.T, v interface{}, what string) map[string]interface{} {
+	t.Helper()
+	obj, ok := v.(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s: expected map[string]interface{}, got %T", what, v)
+	}
+	return obj
+}
+
 func TestParse_valid(t *testing.T) {
 	cases := []struct {
-		path     string
+		path      string
 		wantKinds []segKind
 		wantKeys  []string
 		wantIdxs  []int
@@ -147,11 +167,11 @@ func TestPreservePaths_wildcardArrayField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	arr := merged["domainSettings"].([]interface{})
-	if v := arr[0].(map[string]interface{})["password"]; v != "pass1" {
+	arr := mustArray(t, merged["domainSettings"], "merged[domainSettings]")
+	if v := mustObject(t, arr[0], "arr[0]")["password"]; v != "pass1" {
 		t.Errorf("element[0].password = %v, want %q", v, "pass1")
 	}
-	if v := arr[1].(map[string]interface{})["password"]; v != "pass2" {
+	if v := mustObject(t, arr[1], "arr[1]")["password"]; v != "pass2" {
 		t.Errorf("element[1].password = %v, want %q", v, "pass2")
 	}
 }
@@ -174,11 +194,11 @@ func TestPreservePaths_specificIndexField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	arr := merged["domainSettings"].([]interface{})
-	if _, ok := arr[0].(map[string]interface{})["password"]; ok {
+	arr := mustArray(t, merged["domainSettings"], "merged[domainSettings]")
+	if _, ok := mustObject(t, arr[0], "arr[0]")["password"]; ok {
 		t.Error("element[0].password should not be set")
 	}
-	if v := arr[1].(map[string]interface{})["password"]; v != "secret1" {
+	if v := mustObject(t, arr[1], "arr[1]")["password"]; v != "secret1" {
 		t.Errorf("element[1].password = %v, want %q", v, "secret1")
 	}
 }
@@ -191,7 +211,7 @@ func TestPreservePaths_serverMissingKey(t *testing.T) {
 		"foo": "bar",
 		// "password" absent from server
 	}
-	// Should silently skip; merged unchanged
+	// Should silently skip; merged unchanged.
 	if err := PreservePaths(merged, server, []string{"$.password"}); err != nil {
 		t.Fatal(err)
 	}
@@ -220,11 +240,11 @@ func TestPreservePaths_mergedHasMoreElementsThanServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	arr := merged["settings"].([]interface{})
-	if v := arr[0].(map[string]interface{})["token"]; v != "abc" {
+	arr := mustArray(t, merged["settings"], "merged[settings]")
+	if v := mustObject(t, arr[0], "arr[0]")["token"]; v != "abc" {
 		t.Errorf("element[0].token = %v, want %q", v, "abc")
 	}
-	if _, ok := arr[1].(map[string]interface{})["token"]; ok {
+	if _, ok := mustObject(t, arr[1], "arr[1]")["token"]; ok {
 		t.Error("element[1].token should not be set (new element not in server)")
 	}
 }
@@ -246,7 +266,7 @@ func TestPreservePaths_nestedObject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn := merged["connection"].(map[string]interface{})
+	conn := mustObject(t, merged["connection"], "merged[connection]")
 	if conn["password"] != "secret" {
 		t.Errorf("connection.password = %v, want %q", conn["password"], "secret")
 	}
@@ -287,12 +307,12 @@ func TestPreservePaths_multiplePaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	domArr := merged["domainSettings"].([]interface{})
-	if v := domArr[0].(map[string]interface{})["password"]; v != "pass1" {
+	domArr := mustArray(t, merged["domainSettings"], "merged[domainSettings]")
+	if v := mustObject(t, domArr[0], "domArr[0]")["password"]; v != "pass1" {
 		t.Errorf("domainSettings[0].password = %v, want %q", v, "pass1")
 	}
-	forArr := merged["forestSettings"].([]interface{})
-	if v := forArr[0].(map[string]interface{})["servicePassword"]; v != "pass2" {
+	forArr := mustArray(t, merged["forestSettings"], "merged[forestSettings]")
+	if v := mustObject(t, forArr[0], "forArr[0]")["servicePassword"]; v != "pass2" {
 		t.Errorf("forestSettings[0].servicePassword = %v, want %q", v, "pass2")
 	}
 }

--- a/internal/services/source/source_model.go
+++ b/internal/services/source/source_model.go
@@ -5,10 +5,12 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/jsonpath"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -25,6 +27,7 @@ type sourceModel struct {
 	ConnectorClass            types.String           `tfsdk:"connector_class"`
 	ConnectorAttributes       jsontypes.Normalized   `tfsdk:"connector_attributes"`
 	ConnectorAttributesAll    jsontypes.Normalized   `tfsdk:"connector_attributes_all"`
+	IgnoreAttributesPaths     types.List             `tfsdk:"ignore_attributes_paths"`
 	ConnectionType            types.String           `tfsdk:"connection_type"`
 	Type                      types.String           `tfsdk:"type"`
 	DeleteThreshold           types.Int64            `tfsdk:"delete_threshold"`
@@ -236,9 +239,11 @@ func (m *sourceModel) ToPatchOperations(ctx context.Context, state *sourceModel)
 			if userAttrs != nil {
 				// Start from the full current attributes, then overlay user keys
 				merged := make(map[string]interface{})
+				var serverAttrs map[string]interface{}
 				if fullAttrs, d := common.UnmarshalJSONField[map[string]interface{}](state.ConnectorAttributesAll); fullAttrs != nil {
 					diagnostics.Append(d...)
-					for k, v := range *fullAttrs {
+					serverAttrs = *fullAttrs
+					for k, v := range serverAttrs {
 						merged[k] = v
 					}
 				} else {
@@ -247,6 +252,24 @@ func (m *sourceModel) ToPatchOperations(ctx context.Context, state *sourceModel)
 				for k, v := range *userAttrs {
 					merged[k] = v
 				}
+
+				// Re-inject server values at paths the user wants to ignore, so that
+				// nested server-managed fields (e.g. passwords inside domainSettings)
+				// are not wiped by the top-level array replacement.
+				if !m.IgnoreAttributesPaths.IsNull() && !m.IgnoreAttributesPaths.IsUnknown() && serverAttrs != nil {
+					var paths []string
+					diags = m.IgnoreAttributesPaths.ElementsAs(ctx, &paths, false)
+					diagnostics.Append(diags...)
+					if !diagnostics.HasError() {
+						if err := jsonpath.PreservePaths(merged, serverAttrs, paths); err != nil {
+							diagnostics.AddError(
+								"Invalid ignore_attributes_paths",
+								fmt.Sprintf("Failed to apply ignore_attributes_paths: %s", err),
+							)
+						}
+					}
+				}
+
 				patchOps = append(patchOps, client.NewReplacePatch("/connectorAttributes", merged))
 			}
 		}

--- a/internal/services/source/source_resource.go
+++ b/internal/services/source/source_resource.go
@@ -142,6 +142,14 @@ func (r *sourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Computed:            true,
 				CustomType:          jsontypes.NormalizedType{},
 			},
+			"ignore_attributes_paths": schema.ListAttribute{
+				MarkdownDescription: "A list of JSONPath expressions identifying fields inside `connector_attributes` that should be preserved from the server state rather than overwritten on each apply. " +
+					"Use this to protect server-managed sensitive fields (e.g. passwords) nested inside arrays that you declare in `connector_attributes`. " +
+					"Supported syntax: `$.key`, `$.key.nested`, `$.key[N].field` (specific index), `$.key[*].field` (all elements). " +
+					"Example: `[\"$.domainSettings[*].password\", \"$.forestSettings[*].servicePassword\"]`.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 			"connection_type": schema.StringAttribute{
 				MarkdownDescription: "The connection type (e.g., `direct`, `file`).",
 				Optional:            true,
@@ -269,6 +277,9 @@ func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest,
 		state.ConnectorAttributes = plan.ConnectorAttributes
 	}
 
+	// Preserve Terraform-only fields not populated by FromAPI.
+	state.IgnoreAttributesPaths = plan.IgnoreAttributesPaths
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -327,6 +338,9 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if !priorState.ConnectorAttributes.IsNull() && !priorState.ConnectorAttributes.IsUnknown() {
 		state.ConnectorAttributes = priorState.ConnectorAttributes
 	}
+
+	// Preserve Terraform-only fields not populated by FromAPI.
+	state.IgnoreAttributesPaths = priorState.IgnoreAttributesPaths
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -401,6 +415,9 @@ func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Preserve user-managed connector_attributes from the plan
 	newState.ConnectorAttributes = plan.ConnectorAttributes
+
+	// Preserve Terraform-only fields not populated by FromAPI.
+	newState.IgnoreAttributesPaths = plan.IgnoreAttributesPaths
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
Adds an `ignore_attributes_paths` attribute to the `sailpoint_source` resource that accepts a list of minimal JSONPath expressions. When `connector_attributes` is patched, values at those paths are re-injected from the server state into the merged map before sending to the API.

This prevents server-managed sensitive fields (e.g. passwords nested inside `domainSettings` or `forestSettings` arrays) from being wiped on each apply.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)