### PR TITLE
feat(governance-group): add sailpoint_governance_group resource and data source

### DIFF
--- a/examples/data-sources/sailpoint_governance_group/data-source.tf
+++ b/examples/data-sources/sailpoint_governance_group/data-source.tf
@@ -1,0 +1,16 @@
+# Look up a governance group by ID
+data "sailpoint_governance_group" "by_id" {
+  id = "REPLACE_WITH_GOVERNANCE_GROUP_ID"
+}
+
+# Look up a governance group by name using an ISC filter expression
+data "sailpoint_governance_group" "by_name" {
+  filters = "name eq \"Access Approvers\""
+}
+
+# Use the resolved ID in an approval scheme
+# (example usage — the approval_schemes attribute will be added to sailpoint_role
+# in a future enhancement)
+output "approvers_group_id" {
+  value = data.sailpoint_governance_group.by_name.id
+}

--- a/examples/resources/sailpoint_governance_group/resource.tf
+++ b/examples/resources/sailpoint_governance_group/resource.tf
@@ -1,0 +1,28 @@
+# Minimal governance group — no members
+resource "sailpoint_governance_group" "approvers" {
+  name        = "Access Approvers"
+  description = "Approvers for sensitive access requests."
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+}
+
+# Governance group with declared members
+resource "sailpoint_governance_group" "reviewers" {
+  name        = "Certification Reviewers"
+  description = "Reviewers assigned to quarterly access certification campaigns."
+
+  owner = {
+    type = "IDENTITY"
+    id   = "REPLACE_WITH_OWNER_IDENTITY_ID"
+  }
+
+  # Members are managed declaratively. Changes to this set result in incremental
+  # add/remove calls to the API rather than a full replacement.
+  members = [
+    { type = "IDENTITY", id = "REPLACE_WITH_MEMBER_IDENTITY_ID_1" },
+    { type = "IDENTITY", id = "REPLACE_WITH_MEMBER_IDENTITY_ID_2" },
+  ]
+}

--- a/internal/client/governance_groups.go
+++ b/internal/client/governance_groups.go
@@ -1,0 +1,356 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	governanceGroupEndpointList   = "/v2025/governance-groups"
+	governanceGroupEndpointGet    = "/v2025/governance-groups/{id}"
+	governanceGroupEndpointCreate = "/v2025/governance-groups"
+	governanceGroupEndpointPatch  = "/v2025/governance-groups/{id}"
+	governanceGroupEndpointDelete = "/v2025/governance-groups/{id}"
+	governanceGroupMembersGet     = "/v2025/governance-groups/{id}/members"
+	governanceGroupMembersAdd     = "/v2025/governance-groups/{id}/members"
+	governanceGroupMembersRemove  = "/v2025/governance-groups/{id}/members/bulk-delete"
+)
+
+// GovernanceGroupAPI represents a SailPoint Governance Group from the API.
+type GovernanceGroupAPI struct {
+	ID          string       `json:"id,omitempty"`
+	Name        string       `json:"name"`
+	Description *string      `json:"description,omitempty"`
+	Owner       ObjectRefAPI `json:"owner"`
+	MemberCount *int64       `json:"memberCount,omitempty"`
+	Created     *string      `json:"created,omitempty"`
+	Modified    *string      `json:"modified,omitempty"`
+}
+
+// GovernanceGroupMemberAPI represents a member of a governance group.
+type GovernanceGroupMemberAPI struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+type governanceGroupErrorContext struct {
+	Operation    string
+	ID           string
+	Name         string
+	ResponseBody string
+}
+
+// ListGovernanceGroups retrieves governance groups, optionally filtered.
+// filters is an ISC filter expression (e.g. `name eq "example"`); pass "" for no filter.
+func (c *Client) ListGovernanceGroups(ctx context.Context, filters string) ([]GovernanceGroupAPI, error) {
+	tflog.Debug(ctx, "Listing governance groups", map[string]any{"filters": filters})
+
+	req := c.prepareRequest(ctx)
+	if filters != "" {
+		req = req.SetQueryParam("filters", filters)
+	}
+
+	var result []GovernanceGroupAPI
+	resp, err := req.SetResult(&result).Get(governanceGroupEndpointList)
+	if err != nil {
+		return nil, c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "list"}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "list", ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully listed governance groups", map[string]any{"count": len(result)})
+	return result, nil
+}
+
+// GetGovernanceGroup retrieves a specific governance group by ID.
+func (c *Client) GetGovernanceGroup(ctx context.Context, id string) (*GovernanceGroupAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("governance group ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting governance group", map[string]any{"id": id})
+
+	var result GovernanceGroupAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Get(governanceGroupEndpointGet)
+
+	if err != nil {
+		return nil, c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "get", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "get", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved governance group", map[string]any{"id": id, "name": result.Name})
+	return &result, nil
+}
+
+// CreateGovernanceGroup creates a new governance group.
+func (c *Client) CreateGovernanceGroup(ctx context.Context, gg *GovernanceGroupAPI) (*GovernanceGroupAPI, error) {
+	if gg == nil {
+		return nil, fmt.Errorf("governance group cannot be nil")
+	}
+	if gg.Name == "" {
+		return nil, fmt.Errorf("governance group name cannot be empty")
+	}
+
+	requestBody, _ := json.Marshal(gg)
+	tflog.Debug(ctx, "Creating governance group", map[string]any{
+		"name":         gg.Name,
+		"request_body": string(requestBody),
+	})
+
+	var result GovernanceGroupAPI
+	resp, err := c.prepareRequest(ctx).
+		SetBody(gg).
+		SetResult(&result).
+		Post(governanceGroupEndpointCreate)
+
+	if err != nil {
+		return nil, c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "create", Name: gg.Name}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "create", Name: gg.Name, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully created governance group", map[string]any{"id": result.ID, "name": result.Name})
+	return &result, nil
+}
+
+// PatchGovernanceGroup applies JSON Patch operations to a governance group.
+// When patchOps is empty, it fetches and returns the current state.
+func (c *Client) PatchGovernanceGroup(ctx context.Context, id string, patchOps []JSONPatchOperation) (*GovernanceGroupAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("governance group ID cannot be empty")
+	}
+	if len(patchOps) == 0 {
+		return c.GetGovernanceGroup(ctx, id)
+	}
+
+	requestBody, _ := json.Marshal(patchOps)
+	tflog.Debug(ctx, "Updating governance group (PATCH)", map[string]any{
+		"id":               id,
+		"operations_count": len(patchOps),
+		"request_body":     string(requestBody),
+	})
+
+	var result GovernanceGroupAPI
+	resp, err := c.prepareRequest(ctx).
+		SetHeader("Content-Type", "application/json-patch+json").
+		SetBody(patchOps).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Patch(governanceGroupEndpointPatch)
+
+	if err != nil {
+		return nil, c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "update", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "update", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated governance group", map[string]any{"id": id, "name": result.Name})
+	return &result, nil
+}
+
+// DeleteGovernanceGroup deletes a governance group by ID.
+func (c *Client) DeleteGovernanceGroup(ctx context.Context, id string) error {
+	if id == "" {
+		return fmt.Errorf("governance group ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Deleting governance group", map[string]any{"id": id})
+
+	resp, err := c.prepareRequest(ctx).
+		SetPathParam("id", id).
+		Delete(governanceGroupEndpointDelete)
+
+	if err != nil {
+		return c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "delete", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		if resp.StatusCode() == http.StatusNotFound {
+			tflog.Debug(ctx, "Governance group not found, treating as already deleted", map[string]any{"id": id})
+			return nil
+		}
+		return c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "delete", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully deleted governance group", map[string]any{"id": id})
+	return nil
+}
+
+// ListGovernanceGroupMembers lists all members of a governance group.
+func (c *Client) ListGovernanceGroupMembers(ctx context.Context, id string) ([]GovernanceGroupMemberAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("governance group ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Listing governance group members", map[string]any{"id": id})
+
+	var result []GovernanceGroupMemberAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Get(governanceGroupMembersGet)
+
+	if err != nil {
+		return nil, c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "list members", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "list members", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully listed governance group members", map[string]any{"id": id, "count": len(result)})
+	return result, nil
+}
+
+// AddGovernanceGroupMembers adds members to a governance group.
+func (c *Client) AddGovernanceGroupMembers(ctx context.Context, id string, members []GovernanceGroupMemberAPI) error {
+	if id == "" {
+		return fmt.Errorf("governance group ID cannot be empty")
+	}
+	if len(members) == 0 {
+		return nil
+	}
+
+	tflog.Debug(ctx, "Adding governance group members", map[string]any{"id": id, "count": len(members)})
+
+	resp, err := c.prepareRequest(ctx).
+		SetBody(members).
+		SetPathParam("id", id).
+		Post(governanceGroupMembersAdd)
+
+	if err != nil {
+		return c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "add members", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "add members", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully added governance group members", map[string]any{"id": id, "count": len(members)})
+	return nil
+}
+
+// RemoveGovernanceGroupMembers removes members from a governance group using the bulk-delete endpoint.
+func (c *Client) RemoveGovernanceGroupMembers(ctx context.Context, id string, memberIDs []string) error {
+	if id == "" {
+		return fmt.Errorf("governance group ID cannot be empty")
+	}
+	if len(memberIDs) == 0 {
+		return nil
+	}
+
+	// The bulk-delete endpoint expects a list of identity references.
+	type bulkDeleteItem struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	}
+	items := make([]bulkDeleteItem, len(memberIDs))
+	for i, mid := range memberIDs {
+		items[i] = bulkDeleteItem{Type: "IDENTITY", ID: mid}
+	}
+
+	tflog.Debug(ctx, "Removing governance group members", map[string]any{"id": id, "count": len(memberIDs)})
+
+	resp, err := c.prepareRequest(ctx).
+		SetBody(items).
+		SetPathParam("id", id).
+		Post(governanceGroupMembersRemove)
+
+	if err != nil {
+		return c.formatGovernanceGroupError(governanceGroupErrorContext{Operation: "remove members", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return c.formatGovernanceGroupError(
+			governanceGroupErrorContext{Operation: "remove members", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully removed governance group members", map[string]any{"id": id, "count": len(memberIDs)})
+	return nil
+}
+
+func (c *Client) formatGovernanceGroupError(errCtx governanceGroupErrorContext, err error, statusCode int) error {
+	var baseMsg string
+	switch {
+	case errCtx.ID != "":
+		baseMsg = fmt.Sprintf("failed to %s governance group '%s'", errCtx.Operation, errCtx.ID)
+	case errCtx.Name != "":
+		baseMsg = fmt.Sprintf("failed to %s governance group '%s'", errCtx.Operation, errCtx.Name)
+	default:
+		baseMsg = fmt.Sprintf("failed to %s governance group", errCtx.Operation)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusConflict:
+			return fmt.Errorf("%s: conflict (409)%s", baseMsg, detail)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/access_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/entitlement"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/form_definition"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/governance_group"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_attribute"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/launcher"
@@ -169,6 +170,7 @@ func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.D
 		access_profile.NewAccessProfileDataSource,
 		entitlement.NewEntitlementDataSource,
 		form_definition.NewFormDefinitionDataSource,
+		governance_group.NewGovernanceGroupDataSource,
 		identity_attribute.NewIdentityAttributeDataSource,
 		identity_profile.NewIdentityProfileDataSource,
 		launcher.NewLauncherDataSource,
@@ -189,6 +191,7 @@ func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resou
 		access_profile.NewAccessProfileResource,
 		entitlement.NewEntitlementResource,
 		form_definition.NewFormDefinitionResource,
+		governance_group.NewGovernanceGroupResource,
 		identity_attribute.NewIdentityAttributeResource,
 		identity_profile.NewIdentityProfileResource,
 		launcher.NewLauncherResource,

--- a/internal/services/governance_group/governance_group_data_source.go
+++ b/internal/services/governance_group/governance_group_data_source.go
@@ -1,0 +1,217 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package governance_group
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &governanceGroupDataSource{}
+	_ datasource.DataSourceWithConfigure = &governanceGroupDataSource{}
+)
+
+type governanceGroupDataSource struct {
+	client *client.Client
+}
+
+// governanceGroupDSModel is the datasource-specific model. It extends the
+// resource model with an optional filters input field.
+type governanceGroupDSModel struct {
+	ID          types.String                 `tfsdk:"id"`
+	Filters     types.String                 `tfsdk:"filters"`
+	Name        types.String                 `tfsdk:"name"`
+	Description types.String                 `tfsdk:"description"`
+	Owner       *common.ObjectRefModel       `tfsdk:"owner"`
+	Members     []governanceGroupMemberModel `tfsdk:"members"`
+	MemberCount types.Int64                  `tfsdk:"member_count"`
+	Created     types.String                 `tfsdk:"created"`
+	Modified    types.String                 `tfsdk:"modified"`
+}
+
+// NewGovernanceGroupDataSource creates a new data source for SailPoint Governance Group.
+func NewGovernanceGroupDataSource() datasource.DataSource {
+	return &governanceGroupDataSource{}
+}
+
+func (d *governanceGroupDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_governance_group"
+}
+
+func (d *governanceGroupDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "governance group data source")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = c
+}
+
+func (d *governanceGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data source for SailPoint Governance Group.",
+		MarkdownDescription: "Data source for SailPoint Governance Group. " +
+			"Look up a governance group by `id` or by `filters` (ISC filter expression). " +
+			"Exactly one of `id` or `filters` must be provided.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the governance group. Mutually exclusive with `filters`.",
+			},
+			"filters": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "ISC filter expression to look up the group (e.g. `name eq \"example-group\"`). Mutually exclusive with `id`.",
+			},
+			"name":        schema.StringAttribute{Computed: true},
+			"description": schema.StringAttribute{Computed: true},
+			"owner": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"members": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{Computed: true},
+						"id":   schema.StringAttribute{Computed: true},
+						"name": schema.StringAttribute{Computed: true},
+					},
+				},
+			},
+			"member_count": schema.Int64Attribute{Computed: true},
+			"created":      schema.StringAttribute{Computed: true},
+			"modified":     schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *governanceGroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config governanceGroupDSModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate: exactly one of id or filters must be set.
+	hasID := !config.ID.IsNull() && !config.ID.IsUnknown() && config.ID.ValueString() != ""
+	hasFilters := !config.Filters.IsNull() && !config.Filters.IsUnknown() && config.Filters.ValueString() != ""
+
+	if !hasID && !hasFilters {
+		resp.Diagnostics.AddError(
+			"Missing required argument",
+			"One of `id` or `filters` must be provided.",
+		)
+		return
+	}
+	if hasID && hasFilters {
+		resp.Diagnostics.AddError(
+			"Conflicting arguments",
+			"`id` and `filters` are mutually exclusive. Provide only one.",
+		)
+		return
+	}
+
+	var apiResp *client.GovernanceGroupAPI
+
+	if hasID {
+		tflog.Debug(ctx, "Reading governance group data source by ID", map[string]any{"id": config.ID.ValueString()})
+		gg, err := d.client.GetGovernanceGroup(ctx, config.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading SailPoint Governance Group",
+				fmt.Sprintf("Could not read governance group %q: %s", config.ID.ValueString(), err.Error()),
+			)
+			return
+		}
+		apiResp = gg
+	} else {
+		tflog.Debug(ctx, "Reading governance group data source by filters", map[string]any{"filters": config.Filters.ValueString()})
+		groups, err := d.client.ListGovernanceGroups(ctx, config.Filters.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Listing SailPoint Governance Groups",
+				fmt.Sprintf("Could not list governance groups with filters %q: %s", config.Filters.ValueString(), err.Error()),
+			)
+			return
+		}
+		switch len(groups) {
+		case 0:
+			resp.Diagnostics.AddError(
+				"No governance group found",
+				fmt.Sprintf("No governance group matched filters %q. Verify the filter expression.", config.Filters.ValueString()),
+			)
+			return
+		case 1:
+			apiResp = &groups[0]
+		default:
+			resp.Diagnostics.AddError(
+				"Multiple governance groups found",
+				fmt.Sprintf("filters %q matched %d governance groups. Use a more specific expression or supply `id` directly.", config.Filters.ValueString(), len(groups)),
+			)
+			return
+		}
+	}
+
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Governance Group", "Received nil response from SailPoint API")
+		return
+	}
+
+	members, err := d.client.ListGovernanceGroupMembers(ctx, apiResp.ID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Governance Group Members",
+			fmt.Sprintf("Could not read members for governance group %q: %s", apiResp.ID, err.Error()),
+		)
+		return
+	}
+
+	// Populate the datasource model.
+	config.ID = types.StringValue(apiResp.ID)
+	config.Name = types.StringValue(apiResp.Name)
+	config.Description = stringPtrToTF(apiResp.Description)
+	config.Created = stringPtrToTF(apiResp.Created)
+	config.Modified = stringPtrToTF(apiResp.Modified)
+
+	if apiResp.MemberCount != nil {
+		config.MemberCount = types.Int64Value(*apiResp.MemberCount)
+	} else {
+		config.MemberCount = types.Int64Value(int64(len(members)))
+	}
+
+	owner, diags := common.NewObjectRefFromAPIPtr(ctx, apiResp.Owner)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	config.Owner = owner
+
+	if len(members) > 0 {
+		config.Members = make([]governanceGroupMemberModel, 0, len(members))
+		for _, m := range members {
+			config.Members = append(config.Members, governanceGroupMemberModel{
+				Type: types.StringValue(m.Type),
+				ID:   types.StringValue(m.ID),
+				Name: types.StringValue(m.Name),
+			})
+		}
+	} else {
+		config.Members = nil
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}

--- a/internal/services/governance_group/governance_group_model.go
+++ b/internal/services/governance_group/governance_group_model.go
@@ -1,0 +1,177 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package governance_group
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+type governanceGroupMemberModel struct {
+	Type types.String `tfsdk:"type"`
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type governanceGroupModel struct {
+	ID          types.String                 `tfsdk:"id"`
+	Name        types.String                 `tfsdk:"name"`
+	Description types.String                 `tfsdk:"description"`
+	Owner       *common.ObjectRefModel       `tfsdk:"owner"`
+	Members     []governanceGroupMemberModel `tfsdk:"members"`
+	MemberCount types.Int64                  `tfsdk:"member_count"`
+	Created     types.String                 `tfsdk:"created"`
+	Modified    types.String                 `tfsdk:"modified"`
+}
+
+// ---------------------------------------------------------------------------
+// FromAPI
+// ---------------------------------------------------------------------------
+
+func (m *governanceGroupModel) FromAPI(ctx context.Context, api *client.GovernanceGroupAPI, members []client.GovernanceGroupMemberAPI) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	m.ID = types.StringValue(api.ID)
+	m.Name = types.StringValue(api.Name)
+	m.Description = stringPtrToTF(api.Description)
+	m.Created = stringPtrToTF(api.Created)
+	m.Modified = stringPtrToTF(api.Modified)
+
+	if api.MemberCount != nil {
+		m.MemberCount = types.Int64Value(*api.MemberCount)
+	} else {
+		m.MemberCount = types.Int64Value(int64(len(members)))
+	}
+
+	owner, diags := common.NewObjectRefFromAPIPtr(ctx, api.Owner)
+	diagnostics.Append(diags...)
+	m.Owner = owner
+
+	// Populate members from the separate members API response.
+	if len(members) > 0 {
+		m.Members = make([]governanceGroupMemberModel, 0, len(members))
+		for _, mem := range members {
+			m.Members = append(m.Members, governanceGroupMemberModel{
+				Type: types.StringValue(mem.Type),
+				ID:   types.StringValue(mem.ID),
+				Name: types.StringValue(mem.Name),
+			})
+		}
+	} else {
+		m.Members = nil
+	}
+
+	return diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// ToAPI
+// ---------------------------------------------------------------------------
+
+func (m *governanceGroupModel) ToAPI(ctx context.Context) (*client.GovernanceGroupAPI, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+
+	api := &client.GovernanceGroupAPI{
+		Name: m.Name.ValueString(),
+	}
+
+	if !m.Description.IsNull() && !m.Description.IsUnknown() {
+		v := m.Description.ValueString()
+		api.Description = &v
+	}
+
+	if m.Owner != nil {
+		ownerAPI, diags := common.NewObjectRefToAPI(ctx, *m.Owner)
+		diagnostics.Append(diags...)
+		api.Owner = ownerAPI
+	}
+
+	return api, diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// ToPatchOperations
+// ---------------------------------------------------------------------------
+
+func (m *governanceGroupModel) ToPatchOperations(ctx context.Context, state *governanceGroupModel) ([]client.JSONPatchOperation, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	var ops []client.JSONPatchOperation
+
+	if !m.Name.Equal(state.Name) {
+		ops = append(ops, client.NewReplacePatch("/name", m.Name.ValueString()))
+	}
+
+	if !m.Description.Equal(state.Description) {
+		if !m.Description.IsNull() {
+			ops = append(ops, client.NewReplacePatch("/description", m.Description.ValueString()))
+		} else {
+			ops = append(ops, client.NewRemovePatch("/description"))
+		}
+	}
+
+	if !reflect.DeepEqual(m.Owner, state.Owner) && m.Owner != nil {
+		ownerAPI, diags := common.NewObjectRefToAPI(ctx, *m.Owner)
+		diagnostics.Append(diags...)
+		ops = append(ops, client.NewReplacePatch("/owner", ownerAPI))
+	}
+
+	return ops, diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// Member diff helpers
+// ---------------------------------------------------------------------------
+
+// MemberDiff computes which members to add and which to remove to reconcile
+// the plan members against the current state members.
+func MemberDiff(plan []governanceGroupMemberModel, state []governanceGroupMemberModel) (toAdd []client.GovernanceGroupMemberAPI, toRemoveIDs []string) {
+	stateByID := make(map[string]bool, len(state))
+	for _, m := range state {
+		stateByID[m.ID.ValueString()] = true
+	}
+
+	planByID := make(map[string]bool, len(plan))
+	for _, m := range plan {
+		planByID[m.ID.ValueString()] = true
+	}
+
+	for _, m := range plan {
+		id := m.ID.ValueString()
+		if !stateByID[id] {
+			toAdd = append(toAdd, client.GovernanceGroupMemberAPI{
+				Type: m.Type.ValueString(),
+				ID:   id,
+			})
+		}
+	}
+
+	for _, m := range state {
+		id := m.ID.ValueString()
+		if !planByID[id] {
+			toRemoveIDs = append(toRemoveIDs, id)
+		}
+	}
+
+	return toAdd, toRemoveIDs
+}
+
+// ---------------------------------------------------------------------------
+// Primitive helpers
+// ---------------------------------------------------------------------------
+
+func stringPtrToTF(s *string) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*s)
+}

--- a/internal/services/governance_group/governance_group_resource.go
+++ b/internal/services/governance_group/governance_group_resource.go
@@ -1,0 +1,335 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package governance_group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &governanceGroupResource{}
+	_ resource.ResourceWithConfigure   = &governanceGroupResource{}
+	_ resource.ResourceWithImportState = &governanceGroupResource{}
+)
+
+type governanceGroupResource struct {
+	client *client.Client
+}
+
+// NewGovernanceGroupResource creates a new Governance Group resource.
+func NewGovernanceGroupResource() resource.Resource {
+	return &governanceGroupResource{}
+}
+
+func (r *governanceGroupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_governance_group"
+}
+
+func (r *governanceGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "governance group resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+func memberNestedAttr(required bool) schema.SetNestedAttribute {
+	return schema.SetNestedAttribute{
+		MarkdownDescription: "Identities that are members of this governance group. " +
+			"Member changes are applied incrementally (add/remove) rather than replacing the full list.",
+		Optional: !required,
+		Required: required,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"type": schema.StringAttribute{
+					MarkdownDescription: "Object type. Must be `IDENTITY`.",
+					Required:            true,
+				},
+				"id": schema.StringAttribute{
+					MarkdownDescription: "Identity ID of the member.",
+					Required:            true,
+				},
+				"name": schema.StringAttribute{
+					MarkdownDescription: "Name of the member identity. Server-resolved.",
+					Computed:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *governanceGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Resource for SailPoint Governance Group.",
+		MarkdownDescription: "Resource for SailPoint Governance Group. " +
+			"Governance groups are collections of identities used as approvers in access request and " +
+			"certification workflows. They can be referenced in role `approval_schemes` and certification " +
+			"campaign reviewer configurations.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the governance group.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The name of the governance group.",
+			},
+			"description": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "A description of the governance group.",
+			},
+			"owner": schema.SingleNestedAttribute{
+				Required:            true,
+				MarkdownDescription: "The owner of the governance group. Typically `type = IDENTITY`.",
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Required: true},
+					"id":   schema.StringAttribute{Required: true},
+					"name": schema.StringAttribute{
+						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+				},
+			},
+			"members":      memberNestedAttr(false),
+			"member_count": schema.Int64Attribute{Computed: true, MarkdownDescription: "Total number of members. Server-resolved."},
+			"created": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *governanceGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan governanceGroupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiReq, diags := plan.ToAPI(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.CreateGovernanceGroup(ctx, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Creating SailPoint Governance Group",
+			fmt.Sprintf("Could not create governance group %q: %s", plan.Name.ValueString(), err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Creating SailPoint Governance Group", "Received nil response from SailPoint API")
+		return
+	}
+
+	id := apiResp.ID
+
+	// Add any declared members after creation.
+	if len(plan.Members) > 0 {
+		membersToAdd := make([]client.GovernanceGroupMemberAPI, 0, len(plan.Members))
+		for _, m := range plan.Members {
+			membersToAdd = append(membersToAdd, client.GovernanceGroupMemberAPI{
+				Type: m.Type.ValueString(),
+				ID:   m.ID.ValueString(),
+			})
+		}
+		if err := r.client.AddGovernanceGroupMembers(ctx, id, membersToAdd); err != nil {
+			resp.Diagnostics.AddError(
+				"Error Adding Members to SailPoint Governance Group",
+				fmt.Sprintf("Governance group %q was created but members could not be added: %s", id, err.Error()),
+			)
+			return
+		}
+	}
+
+	members, err := r.client.ListGovernanceGroupMembers(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Governance Group Members",
+			fmt.Sprintf("Could not read members for governance group %q: %s", id, err.Error()),
+		)
+		return
+	}
+
+	var state governanceGroupModel
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp, members)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "Successfully created governance group", map[string]any{
+		"id":   state.ID.ValueString(),
+		"name": state.Name.ValueString(),
+	})
+}
+
+func (r *governanceGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state governanceGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+
+	apiResp, err := r.client.GetGovernanceGroup(ctx, id)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Governance group not found, removing from state", map[string]any{"id": id})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Governance Group",
+			fmt.Sprintf("Could not read governance group %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Governance Group", "Received nil response from SailPoint API")
+		return
+	}
+
+	members, err := r.client.ListGovernanceGroupMembers(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Governance Group Members",
+			fmt.Sprintf("Could not read members for governance group %q: %s", id, err.Error()),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp, members)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *governanceGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan governanceGroupModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state governanceGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+
+	// Apply PATCH for scalar fields.
+	ops, diags := plan.ToPatchOperations(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	apiResp, err := r.client.PatchGovernanceGroup(ctx, id, ops)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating SailPoint Governance Group",
+			fmt.Sprintf("Could not update governance group %q: %s", id, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Updating SailPoint Governance Group", "Received nil response from SailPoint API")
+		return
+	}
+
+	// Reconcile member additions and removals.
+	toAdd, toRemoveIDs := MemberDiff(plan.Members, state.Members)
+
+	if len(toRemoveIDs) > 0 {
+		if err := r.client.RemoveGovernanceGroupMembers(ctx, id, toRemoveIDs); err != nil {
+			resp.Diagnostics.AddError(
+				"Error Removing Members from SailPoint Governance Group",
+				fmt.Sprintf("Could not remove members from governance group %q: %s", id, err.Error()),
+			)
+			return
+		}
+	}
+
+	if len(toAdd) > 0 {
+		if err := r.client.AddGovernanceGroupMembers(ctx, id, toAdd); err != nil {
+			resp.Diagnostics.AddError(
+				"Error Adding Members to SailPoint Governance Group",
+				fmt.Sprintf("Could not add members to governance group %q: %s", id, err.Error()),
+			)
+			return
+		}
+	}
+
+	// Re-read final state to pick up server-resolved names on members.
+	members, err := r.client.ListGovernanceGroupMembers(ctx, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Governance Group Members",
+			fmt.Sprintf("Could not read members for governance group %q after update: %s", id, err.Error()),
+		)
+		return
+	}
+
+	var newState governanceGroupModel
+	resp.Diagnostics.Append(newState.FromAPI(ctx, apiResp, members)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	tflog.Info(ctx, "Successfully updated governance group", map[string]any{
+		"id":      newState.ID.ValueString(),
+		"patches": len(ops),
+	})
+}
+
+func (r *governanceGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state governanceGroupModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := state.ID.ValueString()
+	if err := r.client.DeleteGovernanceGroup(ctx, id); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting SailPoint Governance Group",
+			fmt.Sprintf("Could not delete governance group %q: %s", id, err.Error()),
+		)
+		return
+	}
+}
+
+func (r *governanceGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
## Summary

Adds `sailpoint_governance_group` resource and `data.sailpoint_governance_group` data source. Closes #122.

## Upstream API

- `GET /v2025/governance-groups` — list with optional `filters`
- `POST /v2025/governance-groups` — create
- `GET /v2025/governance-groups/{id}` — read
- `PATCH /v2025/governance-groups/{id}` — update (name, description, owner)
- `DELETE /v2025/governance-groups/{id}` — delete
- `GET /v2025/governance-groups/{id}/members` — list members
- `POST /v2025/governance-groups/{id}/members` — add members
- `POST /v2025/governance-groups/{id}/members/bulk-delete` — remove members

## Schema

**Resource `sailpoint_governance_group`:**
- `id` — String, Computed
- `name` — String, Required
- `description` — String, Optional
- `owner` — SingleNestedAttribute, Required (`type`, `id`, `name` Computed)
- `members` — SetNestedAttribute, Optional (`type` Required, `id` Required, `name` Computed) — managed incrementally via add/remove API calls
- `member_count` — Int64, Computed
- `created` / `modified` — String, Computed

**Data source `data.sailpoint_governance_group`:**
- `id` — String, Optional (direct lookup)
- `filters` — String, Optional (ISC filter expression, e.g. `name eq "..."`)
- All resource attributes as Computed outputs
- Errors if zero or multiple groups match the filter

## Implementation notes

Member reconciliation uses a diff (`MemberDiff`) rather than replace: removals call the bulk-delete endpoint first, then additions call the add-members endpoint. This avoids a full member replacement on every apply and matches ISC's expected usage pattern.

## Test plan

- [x] `make build` — compiles cleanly
- [x] `make lint` — 0 issues
- [x] `make test` — all existing unit tests pass
- [ ] Acceptance tests: `TF_ACC=1 go test -run TestAccGovernanceGroup -timeout 120s` (requires live ISC tenant)
- [ ] Manual import round-trip: `terraform import sailpoint_governance_group.example <id>`
- [ ] Example in `examples/resources/sailpoint_governance_group/` plans cleanly

## Anonymization checklist

- [x] No real tenant IDs, source IDs, identity IDs
- [x] No client or company names
- [x] No internal hostnames, DNs, emails
- [x] Examples use `REPLACE_WITH_*` placeholders