### PR TITLE
feat(identity): add data.sailpoint_identity datasource

### DIFF
--- a/examples/data-sources/sailpoint_identity/data-source.tf
+++ b/examples/data-sources/sailpoint_identity/data-source.tf
@@ -1,0 +1,36 @@
+# Look up an identity by ID
+data "sailpoint_identity" "owner" {
+  id = "REPLACE_WITH_IDENTITY_ID"
+}
+
+# Look up an identity by alias using an ISC filter expression
+data "sailpoint_identity" "owner_by_alias" {
+  filters = "alias eq \"jsmith\""
+}
+
+# Look up an identity by display name
+data "sailpoint_identity" "owner_by_name" {
+  filters = "name eq \"Jane Smith\""
+}
+
+# Use the resolved ID in an owner reference on another resource.
+# This pattern works for sailpoint_source, sailpoint_role,
+# sailpoint_access_profile, and other resources with owner fields.
+resource "sailpoint_transform" "example" {
+  name = "Example Transform"
+  type = "static"
+
+  attributes = jsonencode({
+    value = "example"
+  })
+}
+
+output "identity_id" {
+  description = "Resolved identity ID — usable in owner references."
+  value       = data.sailpoint_identity.owner_by_alias.id
+}
+
+output "identity_lifecycle_state" {
+  description = "Current lifecycle state name of the identity."
+  value       = data.sailpoint_identity.owner_by_alias.lifecycle_state != null ? data.sailpoint_identity.owner_by_alias.lifecycle_state.state_name : null
+}

--- a/internal/client/identities.go
+++ b/internal/client/identities.go
@@ -1,0 +1,144 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	identityEndpointGet  = "/v2025/identities/{id}"
+	identityEndpointList = "/v2025/identities"
+)
+
+// IdentityAPI represents a SailPoint Identity from the full identities endpoint.
+type IdentityAPI struct {
+	ID              string            `json:"id"`
+	Name            string            `json:"name"`
+	Alias           string            `json:"alias,omitempty"`
+	EmailAddress    *string           `json:"emailAddress,omitempty"`
+	Status          *string           `json:"status,omitempty"`
+	EmployeeNumber  *string           `json:"employeeNumber,omitempty"`
+	IsManager       *bool             `json:"isManager,omitempty"`
+	Manager         *ObjectRefAPI     `json:"manager,omitempty"`
+	IdentityProfile *ObjectRefAPI     `json:"identityProfile,omitempty"`
+	Source          *ObjectRefAPI     `json:"source,omitempty"`
+	LifecycleState  *IdentityLCSAPI   `json:"lifecycleState,omitempty"`
+	Attributes      map[string]string `json:"attributes,omitempty"`
+	Created         *string           `json:"created,omitempty"`
+	Modified        *string           `json:"modified,omitempty"`
+}
+
+// IdentityLCSAPI represents the lifecycle state reference on an identity.
+type IdentityLCSAPI struct {
+	ID        *string `json:"id,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	StateName *string `json:"stateName,omitempty"`
+}
+
+type identityErrorContext struct {
+	Operation    string
+	ID           string
+	ResponseBody string
+}
+
+// GetIdentity retrieves a specific identity by ID.
+func (c *Client) GetIdentity(ctx context.Context, id string) (*IdentityAPI, error) {
+	if id == "" {
+		return nil, fmt.Errorf("identity ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting identity", map[string]any{"id": id})
+
+	var result IdentityAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&result).
+		SetPathParam("id", id).
+		Get(identityEndpointGet)
+
+	if err != nil {
+		return nil, c.formatIdentityError(identityErrorContext{Operation: "get", ID: id}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatIdentityError(
+			identityErrorContext{Operation: "get", ID: id, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved identity", map[string]any{"id": id, "name": result.Name})
+	return &result, nil
+}
+
+// ListIdentities retrieves identities, optionally filtered.
+// filters is an ISC filter expression (e.g. `alias eq "jsmith"`); pass "" for no filter.
+// limit controls how many results to fetch; use 0 for the default (API default is 250).
+func (c *Client) ListIdentities(ctx context.Context, filters string, limit int) ([]IdentityAPI, error) {
+	tflog.Debug(ctx, "Listing identities", map[string]any{"filters": filters, "limit": limit})
+
+	req := c.prepareRequest(ctx)
+	if filters != "" {
+		req = req.SetQueryParam("filters", filters)
+	}
+	if limit > 0 {
+		req = req.SetQueryParam("limit", fmt.Sprintf("%d", limit))
+	}
+
+	var result []IdentityAPI
+	resp, err := req.SetResult(&result).Get(identityEndpointList)
+	if err != nil {
+		return nil, c.formatIdentityError(identityErrorContext{Operation: "list"}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatIdentityError(
+			identityErrorContext{Operation: "list", ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully listed identities", map[string]any{"count": len(result)})
+	return result, nil
+}
+
+func (c *Client) formatIdentityError(errCtx identityErrorContext, err error, statusCode int) error {
+	var baseMsg string
+	if errCtx.ID != "" {
+		baseMsg = fmt.Sprintf("failed to %s identity '%s'", errCtx.Operation, errCtx.ID)
+	} else {
+		baseMsg = fmt.Sprintf("failed to %s identit%s", errCtx.Operation, map[bool]string{true: "y", false: "ies"}[errCtx.ID != ""])
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/access_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/entitlement"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/form_definition"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_attribute"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/identity_profile"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/launcher"
@@ -169,6 +170,7 @@ func (p *sailpointProvider) DataSources(_ context.Context) []func() datasource.D
 		access_profile.NewAccessProfileDataSource,
 		entitlement.NewEntitlementDataSource,
 		form_definition.NewFormDefinitionDataSource,
+		identity.NewIdentityDataSource,
 		identity_attribute.NewIdentityAttributeDataSource,
 		identity_profile.NewIdentityProfileDataSource,
 		launcher.NewLauncherDataSource,

--- a/internal/services/identity/identity_data_source.go
+++ b/internal/services/identity/identity_data_source.go
@@ -1,0 +1,316 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &identityDataSource{}
+	_ datasource.DataSourceWithConfigure = &identityDataSource{}
+)
+
+type identityDataSource struct {
+	client *client.Client
+}
+
+// identityDSModel is the datasource model for a SailPoint Identity.
+type identityDSModel struct {
+	// Inputs — exactly one must be set.
+	ID      types.String `tfsdk:"id"`
+	Filters types.String `tfsdk:"filters"`
+
+	// Outputs.
+	Name            types.String             `tfsdk:"name"`
+	Alias           types.String             `tfsdk:"alias"`
+	EmailAddress    types.String             `tfsdk:"email_address"`
+	Status          types.String             `tfsdk:"status"`
+	EmployeeNumber  types.String             `tfsdk:"employee_number"`
+	IsManager       types.Bool               `tfsdk:"is_manager"`
+	Manager         *common.ObjectRefModel   `tfsdk:"manager"`
+	IdentityProfile *identityProfileRefModel `tfsdk:"identity_profile"`
+	Source          *common.ObjectRefModel   `tfsdk:"source"`
+	LifecycleState  *identityLCSModel        `tfsdk:"lifecycle_state"`
+	Attributes      types.Map                `tfsdk:"attributes"`
+	Created         types.String             `tfsdk:"created"`
+	Modified        types.String             `tfsdk:"modified"`
+}
+
+type identityProfileRefModel struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type identityLCSModel struct {
+	ID        types.String `tfsdk:"id"`
+	Name      types.String `tfsdk:"name"`
+	StateName types.String `tfsdk:"state_name"`
+}
+
+// NewIdentityDataSource creates a new data source for SailPoint Identity.
+func NewIdentityDataSource() datasource.DataSource {
+	return &identityDataSource{}
+}
+
+func (d *identityDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_identity"
+}
+
+func (d *identityDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "identity data source")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = c
+}
+
+func (d *identityDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data source for SailPoint Identity.",
+		MarkdownDescription: "Data source for SailPoint Identity. " +
+			"Look up a full identity by `id` or by `filters` (ISC filter expression). " +
+			"Exactly one of `id` or `filters` must be provided. " +
+			"Identities are not created by Terraform — they are derived from source aggregation. " +
+			"Use this data source to resolve an identity by alias or name and reference its ID in " +
+			"`owner` fields on other resources.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "The unique identifier of the identity. Mutually exclusive with `filters`.",
+			},
+			"filters": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "ISC filter expression (e.g. `alias eq \"jsmith\"` or `name eq \"Jane Smith\"`). Mutually exclusive with `id`. Returns an error if zero or more than one identity matches.",
+			},
+			"name": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The display name of the identity.",
+			},
+			"alias": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The login alias (username) of the identity.",
+			},
+			"email_address": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The email address of the identity.",
+			},
+			"status": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The status of the identity (e.g. `ACTIVE`, `INACTIVE`).",
+			},
+			"employee_number": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The employee number of the identity.",
+			},
+			"is_manager": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the identity is a manager.",
+			},
+			"manager": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The manager of the identity.",
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"identity_profile": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The identity profile this identity belongs to.",
+				Attributes: map[string]schema.Attribute{
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"source": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The authoritative source for this identity.",
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"lifecycle_state": schema.SingleNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "The current lifecycle state of the identity.",
+				Attributes: map[string]schema.Attribute{
+					"id":         schema.StringAttribute{Computed: true},
+					"name":       schema.StringAttribute{Computed: true},
+					"state_name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"attributes": schema.MapAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Additional identity attributes as key-value pairs. Keys depend on the org's identity schema.",
+			},
+			"created":  schema.StringAttribute{Computed: true},
+			"modified": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *identityDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config identityDSModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	hasID := !config.ID.IsNull() && !config.ID.IsUnknown() && config.ID.ValueString() != ""
+	hasFilters := !config.Filters.IsNull() && !config.Filters.IsUnknown() && config.Filters.ValueString() != ""
+
+	if !hasID && !hasFilters {
+		resp.Diagnostics.AddError(
+			"Missing required argument",
+			"One of `id` or `filters` must be provided.",
+		)
+		return
+	}
+	if hasID && hasFilters {
+		resp.Diagnostics.AddError(
+			"Conflicting arguments",
+			"`id` and `filters` are mutually exclusive. Provide only one.",
+		)
+		return
+	}
+
+	var apiResp *client.IdentityAPI
+
+	if hasID {
+		tflog.Debug(ctx, "Reading identity data source by ID", map[string]any{"id": config.ID.ValueString()})
+		identity, err := d.client.GetIdentity(ctx, config.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading SailPoint Identity",
+				fmt.Sprintf("Could not read identity %q: %s", config.ID.ValueString(), err.Error()),
+			)
+			return
+		}
+		apiResp = identity
+	} else {
+		tflog.Debug(ctx, "Reading identity data source by filters", map[string]any{"filters": config.Filters.ValueString()})
+		// Fetch up to 2 results — we only accept exactly 1.
+		identities, err := d.client.ListIdentities(ctx, config.Filters.ValueString(), 2)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Listing SailPoint Identities",
+				fmt.Sprintf("Could not list identities with filters %q: %s", config.Filters.ValueString(), err.Error()),
+			)
+			return
+		}
+		switch len(identities) {
+		case 0:
+			resp.Diagnostics.AddError(
+				"No identity found",
+				fmt.Sprintf("No identity matched filters %q. Verify the filter expression.", config.Filters.ValueString()),
+			)
+			return
+		case 1:
+			apiResp = &identities[0]
+		default:
+			resp.Diagnostics.AddError(
+				"Multiple identities found",
+				fmt.Sprintf("filters %q matched more than one identity. Use a more specific expression or supply `id` directly.", config.Filters.ValueString()),
+			)
+			return
+		}
+	}
+
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading SailPoint Identity", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(populateIdentityDSModel(ctx, &config, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+func populateIdentityDSModel(ctx context.Context, m *identityDSModel, api *client.IdentityAPI) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+
+	m.ID = types.StringValue(api.ID)
+	m.Name = types.StringValue(api.Name)
+	m.Alias = types.StringValue(api.Alias)
+	m.EmailAddress = stringPtrToTF(api.EmailAddress)
+	m.Status = stringPtrToTF(api.Status)
+	m.EmployeeNumber = stringPtrToTF(api.EmployeeNumber)
+	m.Created = stringPtrToTF(api.Created)
+	m.Modified = stringPtrToTF(api.Modified)
+
+	if api.IsManager != nil {
+		m.IsManager = types.BoolValue(*api.IsManager)
+	} else {
+		m.IsManager = types.BoolNull()
+	}
+
+	if api.Manager != nil {
+		ref, diags := common.NewObjectRefFromAPIPtr(ctx, *api.Manager)
+		diagnostics.Append(diags...)
+		m.Manager = ref
+	} else {
+		m.Manager = nil
+	}
+
+	if api.IdentityProfile != nil {
+		m.IdentityProfile = &identityProfileRefModel{
+			ID:   types.StringValue(api.IdentityProfile.ID),
+			Name: types.StringValue(api.IdentityProfile.Name),
+		}
+	} else {
+		m.IdentityProfile = nil
+	}
+
+	if api.Source != nil {
+		ref, diags := common.NewObjectRefFromAPIPtr(ctx, *api.Source)
+		diagnostics.Append(diags...)
+		m.Source = ref
+	} else {
+		m.Source = nil
+	}
+
+	if api.LifecycleState != nil {
+		lcs := &identityLCSModel{}
+		lcs.ID = stringPtrToTF(api.LifecycleState.ID)
+		lcs.Name = stringPtrToTF(api.LifecycleState.Name)
+		lcs.StateName = stringPtrToTF(api.LifecycleState.StateName)
+		m.LifecycleState = lcs
+	} else {
+		m.LifecycleState = nil
+	}
+
+	if len(api.Attributes) > 0 {
+		attrMap, diags := types.MapValueFrom(ctx, types.StringType, api.Attributes)
+		diagnostics.Append(diags...)
+		m.Attributes = attrMap
+	} else {
+		m.Attributes = types.MapNull(types.StringType)
+	}
+
+	return diagnostics
+}
+
+func stringPtrToTF(s *string) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*s)
+}


### PR DESCRIPTION
## Summary

Adds `data.sailpoint_identity` datasource for full identity lookup. Closes #125.

## Upstream API

- `GET /v2025/identities/{id}` — direct lookup by ID
- `GET /v2025/identities?filters=<expr>&limit=2` — filter-based lookup (limit 2 to detect ambiguity)

## Schema

Inputs (exactly one required):
- `id` — String, Optional (direct ID lookup)
- `filters` — String, Optional (ISC filter expression, e.g. `alias eq "jsmith"`)

Outputs (all Computed):
- `id`, `name`, `alias`, `email_address`, `status`, `employee_number`, `is_manager`
- `manager` — SingleNestedAttribute (`type`, `id`, `name`)
- `identity_profile` — SingleNestedAttribute (`id`, `name`)
- `source` — SingleNestedAttribute (`type`, `id`, `name`) — authoritative source
- `lifecycle_state` — SingleNestedAttribute (`id`, `name`, `state_name`)
- `attributes` — Map of String (extensible identity attributes)
- `created`, `modified`

## Implementation notes

- Filter lookup fetches `limit=2` and fails with a clear diagnostic if zero or multiple identities match — prevents silent misresolution.
- Uses the full `/v2025/identities` endpoint, not `/v2025/public-identities` (which returns a reduced attribute set). The existing `internal/client/public_identities.go` is unchanged.

## Test plan

- [x] `make build` — compiles cleanly
- [x] `make lint` — 0 issues
- [x] `make test` — all existing unit tests pass
- [ ] Acceptance tests: `TF_ACC=1 go test -run TestAccDataSourceIdentity -timeout 120s` (requires live ISC tenant)
- [ ] Verify lookup by `id` returns correct attributes
- [ ] Verify lookup by `filters` with zero results returns a clear error
- [ ] Verify lookup by `filters` with multiple results returns a clear error

## Anonymization checklist

- [x] No real tenant IDs, identity IDs
- [x] No client or company names
- [x] Examples use `REPLACE_WITH_*` placeholders and generic aliases (`jsmith`, `Jane Smith`)