### PR TITLE
feat(source-correlation-config): add sailpoint_source_correlation_config resource

### DIFF
--- a/examples/resources/sailpoint_source_correlation_config/resource.tf
+++ b/examples/resources/sailpoint_source_correlation_config/resource.tf
@@ -1,0 +1,23 @@
+# Correlation config for an Active Directory source.
+#
+# Correlation determines how incoming account records are matched to known
+# identities. The most common pattern is to correlate by a unique account
+# attribute (e.g. sAMAccountName) against a unique identity attribute (e.g. uid).
+#
+# This is a singleton-per-source resource. Create adopts the existing config
+# (it always exists for a source) and Delete is a no-op — removing this resource
+# from Terraform only removes it from Terraform state; the config persists in ISC.
+resource "sailpoint_source_correlation_config" "ad" {
+  source_id = sailpoint_source.ad.id
+
+  attribute_assignments = [
+    {
+      property  = "sAMAccountName"
+      value     = "uid"
+      operation = "EQ"
+    },
+  ]
+}
+
+# Import an existing correlation config into Terraform state:
+#   terraform import sailpoint_source_correlation_config.ad <source-id>

--- a/internal/client/source_correlation_config.go
+++ b/internal/client/source_correlation_config.go
@@ -1,0 +1,143 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	sourceCorrelationConfigGet = "/v2025/sources/{sourceId}/correlation-config"
+	sourceCorrelationConfigPut = "/v2025/sources/{sourceId}/correlation-config"
+)
+
+// SourceCorrelationConfigAPI represents a SailPoint source correlation config.
+type SourceCorrelationConfigAPI struct {
+	ID                   *string                             `json:"id,omitempty"`
+	Name                 *string                             `json:"name,omitempty"`
+	AttributeAssignments []CorrelationAttributeAssignmentAPI `json:"attributeAssignments,omitempty"`
+}
+
+// CorrelationAttributeAssignmentAPI is a single account-to-identity attribute mapping.
+type CorrelationAttributeAssignmentAPI struct {
+	Property     string  `json:"property"`
+	Value        string  `json:"value"`
+	Operation    *string `json:"operation,omitempty"`
+	Complex      *bool   `json:"complex,omitempty"`
+	IgnoreCase   *bool   `json:"ignoreCase,omitempty"`
+	MatchMode    *string `json:"matchMode,omitempty"`
+	FilterString *string `json:"filterString,omitempty"`
+}
+
+type sourceCorrelationConfigErrorContext struct {
+	Operation    string
+	SourceID     string
+	ResponseBody string
+}
+
+// GetSourceCorrelationConfig retrieves the correlation config for a source.
+func (c *Client) GetSourceCorrelationConfig(ctx context.Context, sourceID string) (*SourceCorrelationConfigAPI, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("source ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting source correlation config", map[string]any{"source_id": sourceID})
+
+	var result SourceCorrelationConfigAPI
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&result).
+		SetPathParam("sourceId", sourceID).
+		Get(sourceCorrelationConfigGet)
+
+	if err != nil {
+		return nil, c.formatSourceCorrelationConfigError(sourceCorrelationConfigErrorContext{Operation: "get", SourceID: sourceID}, err, 0)
+	}
+	if resp.IsError() {
+		return nil, c.formatSourceCorrelationConfigError(
+			sourceCorrelationConfigErrorContext{Operation: "get", SourceID: sourceID, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved source correlation config", map[string]any{"source_id": sourceID})
+	return &result, nil
+}
+
+// PutSourceCorrelationConfig replaces the correlation config for a source.
+func (c *Client) PutSourceCorrelationConfig(ctx context.Context, sourceID string, cfg *SourceCorrelationConfigAPI) (*SourceCorrelationConfigAPI, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("source ID cannot be empty")
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("correlation config cannot be nil")
+	}
+
+	requestBody, _ := json.Marshal(cfg)
+	tflog.Debug(ctx, "Updating source correlation config (PUT)", map[string]any{
+		"source_id":    sourceID,
+		"request_body": string(requestBody),
+	})
+
+	var result SourceCorrelationConfigAPI
+	resp, err := c.prepareRequest(ctx).
+		SetBody(cfg).
+		SetResult(&result).
+		SetPathParam("sourceId", sourceID).
+		Put(sourceCorrelationConfigPut)
+
+	if err != nil {
+		return nil, c.formatSourceCorrelationConfigError(sourceCorrelationConfigErrorContext{Operation: "update", SourceID: sourceID}, err, 0)
+	}
+	if resp.IsError() {
+		tflog.Error(ctx, "SailPoint API error response", map[string]any{
+			"status_code":   resp.StatusCode(),
+			"response_body": string(resp.Bytes()),
+		})
+		return nil, c.formatSourceCorrelationConfigError(
+			sourceCorrelationConfigErrorContext{Operation: "update", SourceID: sourceID, ResponseBody: string(resp.Bytes())},
+			nil, resp.StatusCode(),
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated source correlation config", map[string]any{"source_id": sourceID})
+	return &result, nil
+}
+
+func (c *Client) formatSourceCorrelationConfigError(errCtx sourceCorrelationConfigErrorContext, err error, statusCode int) error {
+	baseMsg := fmt.Sprintf("failed to %s source correlation config for source '%s'", errCtx.Operation, errCtx.SourceID)
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/role"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/segment"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/source"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/source_correlation_config"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/transform"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/workflow"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/workflow_trigger"
@@ -198,6 +199,7 @@ func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resou
 		source.NewSourceResource,
 		source.NewSourceSchemaResource,
 		source.NewSourceProvisioningPolicyResource,
+		source_correlation_config.NewSourceCorrelationConfigResource,
 		transform.NewTransformResource,
 		workflow.NewWorkflowResource,
 		workflow_trigger.NewWorkflowTriggerResource,

--- a/internal/services/source_correlation_config/source_correlation_config_model.go
+++ b/internal/services/source_correlation_config/source_correlation_config_model.go
@@ -1,0 +1,143 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source_correlation_config
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+type correlationAttributeAssignmentModel struct {
+	Property     types.String `tfsdk:"property"`
+	Value        types.String `tfsdk:"value"`
+	Operation    types.String `tfsdk:"operation"`
+	Complex      types.Bool   `tfsdk:"complex"`
+	IgnoreCase   types.Bool   `tfsdk:"ignore_case"`
+	MatchMode    types.String `tfsdk:"match_mode"`
+	FilterString types.String `tfsdk:"filter_string"`
+}
+
+type sourceCorrelationConfigModel struct {
+	ID                   types.String                          `tfsdk:"id"`
+	SourceID             types.String                          `tfsdk:"source_id"`
+	Name                 types.String                          `tfsdk:"name"`
+	AttributeAssignments []correlationAttributeAssignmentModel `tfsdk:"attribute_assignments"`
+}
+
+// ---------------------------------------------------------------------------
+// FromAPI
+// ---------------------------------------------------------------------------
+
+func (m *sourceCorrelationConfigModel) FromAPI(_ context.Context, api *client.SourceCorrelationConfigAPI) diag.Diagnostics {
+	// id mirrors source_id for import convenience.
+	m.ID = m.SourceID
+
+	if api.Name != nil {
+		m.Name = types.StringValue(*api.Name)
+	} else {
+		m.Name = types.StringNull()
+	}
+
+	if len(api.AttributeAssignments) > 0 {
+		m.AttributeAssignments = make([]correlationAttributeAssignmentModel, 0, len(api.AttributeAssignments))
+		for _, a := range api.AttributeAssignments {
+			m.AttributeAssignments = append(m.AttributeAssignments, assignmentFromAPI(a))
+		}
+	} else {
+		m.AttributeAssignments = nil
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ToAPI
+// ---------------------------------------------------------------------------
+
+func (m *sourceCorrelationConfigModel) ToAPI() *client.SourceCorrelationConfigAPI {
+	cfg := &client.SourceCorrelationConfigAPI{}
+
+	assignments := make([]client.CorrelationAttributeAssignmentAPI, 0, len(m.AttributeAssignments))
+	for _, a := range m.AttributeAssignments {
+		assignments = append(assignments, assignmentToAPI(a))
+	}
+	cfg.AttributeAssignments = assignments
+
+	return cfg
+}
+
+// ---------------------------------------------------------------------------
+// NeedsUpdate compares plan to state — returns true when attribute_assignments differ.
+// ---------------------------------------------------------------------------
+
+func (m *sourceCorrelationConfigModel) NeedsUpdate(state *sourceCorrelationConfigModel) bool {
+	return !reflect.DeepEqual(m.AttributeAssignments, state.AttributeAssignments)
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+func assignmentFromAPI(a client.CorrelationAttributeAssignmentAPI) correlationAttributeAssignmentModel {
+	m := correlationAttributeAssignmentModel{
+		Property:     types.StringValue(a.Property),
+		Value:        types.StringValue(a.Value),
+		Operation:    stringPtrToTF(a.Operation),
+		Complex:      boolPtrToTF(a.Complex),
+		IgnoreCase:   boolPtrToTF(a.IgnoreCase),
+		MatchMode:    stringPtrToTF(a.MatchMode),
+		FilterString: stringPtrToTF(a.FilterString),
+	}
+	return m
+}
+
+func assignmentToAPI(m correlationAttributeAssignmentModel) client.CorrelationAttributeAssignmentAPI {
+	a := client.CorrelationAttributeAssignmentAPI{
+		Property: m.Property.ValueString(),
+		Value:    m.Value.ValueString(),
+	}
+	if !m.Operation.IsNull() && !m.Operation.IsUnknown() {
+		v := m.Operation.ValueString()
+		a.Operation = &v
+	}
+	if !m.Complex.IsNull() && !m.Complex.IsUnknown() {
+		v := m.Complex.ValueBool()
+		a.Complex = &v
+	}
+	if !m.IgnoreCase.IsNull() && !m.IgnoreCase.IsUnknown() {
+		v := m.IgnoreCase.ValueBool()
+		a.IgnoreCase = &v
+	}
+	if !m.MatchMode.IsNull() && !m.MatchMode.IsUnknown() {
+		v := m.MatchMode.ValueString()
+		a.MatchMode = &v
+	}
+	if !m.FilterString.IsNull() && !m.FilterString.IsUnknown() {
+		v := m.FilterString.ValueString()
+		a.FilterString = &v
+	}
+	return a
+}
+
+func stringPtrToTF(s *string) types.String {
+	if s == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*s)
+}
+
+func boolPtrToTF(b *bool) types.Bool {
+	if b == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*b)
+}

--- a/internal/services/source_correlation_config/source_correlation_config_resource.go
+++ b/internal/services/source_correlation_config/source_correlation_config_resource.go
@@ -1,0 +1,296 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source_correlation_config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &sourceCorrelationConfigResource{}
+	_ resource.ResourceWithConfigure   = &sourceCorrelationConfigResource{}
+	_ resource.ResourceWithImportState = &sourceCorrelationConfigResource{}
+)
+
+type sourceCorrelationConfigResource struct {
+	client *client.Client
+}
+
+// NewSourceCorrelationConfigResource creates a new resource for SailPoint source correlation config.
+func NewSourceCorrelationConfigResource() resource.Resource {
+	return &sourceCorrelationConfigResource{}
+}
+
+func (r *sourceCorrelationConfigResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_source_correlation_config"
+}
+
+func (r *sourceCorrelationConfigResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "source correlation config resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+func attributeAssignmentNestedAttr() schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
+		Required: true,
+		MarkdownDescription: "List of account-to-identity attribute mappings that drive correlation. " +
+			"Each entry maps a source account attribute (`property`) to an identity attribute (`value`).",
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"property": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "The source account attribute name (e.g. `sAMAccountName`).",
+				},
+				"value": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "The identity attribute name to correlate against (e.g. `uid`).",
+				},
+				"operation": schema.StringAttribute{
+					Optional:            true,
+					Computed:            true,
+					MarkdownDescription: "Comparison operation. Defaults to `EQ`.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"complex": schema.BoolAttribute{
+					Optional:            true,
+					Computed:            true,
+					MarkdownDescription: "Whether the assignment uses a complex expression. Server-resolved when not set.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"ignore_case": schema.BoolAttribute{
+					Optional:            true,
+					Computed:            true,
+					MarkdownDescription: "Whether the comparison is case-insensitive.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"match_mode": schema.StringAttribute{
+					Optional:            true,
+					Computed:            true,
+					MarkdownDescription: "Match mode for string comparisons (e.g. `ANYWHERE`, `START`, `END`, `EXACT`).",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"filter_string": schema.StringAttribute{
+					Optional:            true,
+					MarkdownDescription: "An additional filter expression applied to candidate accounts before correlation.",
+				},
+			},
+		},
+	}
+}
+
+func (r *sourceCorrelationConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Resource for SailPoint Source Correlation Config.",
+		MarkdownDescription: "Manages the correlation configuration for a SailPoint source. " +
+			"Correlation config determines how incoming account data is matched to known identities. " +
+			"\n\n" +
+			"This is a singleton-per-source resource using an adopt-only lifecycle: " +
+			"Create reads the existing config and applies any declared changes, " +
+			"Update replaces the config via PUT, and Delete is a no-op that only removes the resource " +
+			"from Terraform state (the config always exists on the server).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Resource identifier — mirrors `source_id` for import convenience.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"source_id": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The ID of the source whose correlation config is being managed.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Server-assigned name of the correlation config (e.g. `AD Correlation Config`).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"attribute_assignments": attributeAssignmentNestedAttr(),
+		},
+	}
+}
+
+// Create adopts the existing correlation config for a source. If the plan differs
+// from the current server state, it issues a PUT to apply the changes.
+func (r *sourceCorrelationConfigResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan sourceCorrelationConfigModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := plan.SourceID.ValueString()
+	tflog.Debug(ctx, "Adopting source correlation config", map[string]any{"source_id": sourceID})
+
+	existing, err := r.client.GetSourceCorrelationConfig(ctx, sourceID)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			resp.Diagnostics.AddError(
+				"Source not found",
+				fmt.Sprintf("Source %q does not exist in SailPoint ISC.", sourceID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error adopting Source Correlation Config",
+			fmt.Sprintf("Could not read correlation config for source %q: %s", sourceID, err.Error()),
+		)
+		return
+	}
+	if existing == nil {
+		resp.Diagnostics.AddError("Error adopting Source Correlation Config", "Received nil response from SailPoint API")
+		return
+	}
+
+	// Populate a baseline from the API response so we can diff.
+	var current sourceCorrelationConfigModel
+	current.SourceID = plan.SourceID
+	resp.Diagnostics.Append(current.FromAPI(ctx, existing)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	final := existing
+	if plan.NeedsUpdate(&current) {
+		apiReq := plan.ToAPI()
+		updated, err := r.client.PutSourceCorrelationConfig(ctx, sourceID, apiReq)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error applying initial changes to Source Correlation Config",
+				fmt.Sprintf("Could not update correlation config for source %q: %s", sourceID, err.Error()),
+			)
+			return
+		}
+		if updated != nil {
+			final = updated
+		}
+	}
+
+	var state sourceCorrelationConfigModel
+	state.SourceID = plan.SourceID
+	resp.Diagnostics.Append(state.FromAPI(ctx, final)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	tflog.Info(ctx, "Successfully adopted source correlation config", map[string]any{"source_id": sourceID})
+}
+
+func (r *sourceCorrelationConfigResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state sourceCorrelationConfigModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := state.SourceID.ValueString()
+	apiResp, err := r.client.GetSourceCorrelationConfig(ctx, sourceID)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Source not found, removing correlation config from state", map[string]any{"source_id": sourceID})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading Source Correlation Config",
+			fmt.Sprintf("Could not read correlation config for source %q: %s", sourceID, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Reading Source Correlation Config", "Received nil response from SailPoint API")
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *sourceCorrelationConfigResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan sourceCorrelationConfigModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state sourceCorrelationConfigModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := state.SourceID.ValueString()
+	plan.SourceID = state.SourceID
+
+	apiReq := plan.ToAPI()
+	apiResp, err := r.client.PutSourceCorrelationConfig(ctx, sourceID, apiReq)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating Source Correlation Config",
+			fmt.Sprintf("Could not update correlation config for source %q: %s", sourceID, err.Error()),
+		)
+		return
+	}
+	if apiResp == nil {
+		resp.Diagnostics.AddError("Error Updating Source Correlation Config", "Received nil response from SailPoint API")
+		return
+	}
+
+	var newState sourceCorrelationConfigModel
+	newState.SourceID = state.SourceID
+	resp.Diagnostics.Append(newState.FromAPI(ctx, apiResp)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	tflog.Info(ctx, "Successfully updated source correlation config", map[string]any{"source_id": sourceID})
+}
+
+// Delete is a no-op — correlation configs always exist on the server;
+// this only removes the resource from Terraform state.
+func (r *sourceCorrelationConfigResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddWarning(
+		"Source Correlation Config not deleted from SailPoint ISC",
+		"Correlation configs always exist for a source and cannot be deleted via the API. "+
+			"The resource has been removed from Terraform state, but the config still exists in ISC.",
+	)
+}
+
+// ImportState imports via source_id.
+func (r *sourceCorrelationConfigResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import by source_id: set both source_id and id to the provided value.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("source_id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+}


### PR DESCRIPTION
## Summary

Adds `sailpoint_source_correlation_config` resource for managing source correlation configuration as code. Closes #124.

## Upstream API

- `GET /v2025/sources/{sourceId}/correlation-config` — read current config
- `PUT /v2025/sources/{sourceId}/correlation-config` — replace config

No create or delete endpoint exists — this uses an adopt-only lifecycle identical to `sailpoint_entitlement`.

## Schema

- `id` — String, Computed (mirrors `source_id`)
- `source_id` — String, Required, RequiresReplace
- `name` — String, Computed (server-assigned, e.g. `"AD Correlation Config"`)
- `attribute_assignments` — ListNestedAttribute, Required
  - `property` — String, Required (source account attribute name)
  - `value` — String, Required (identity attribute name)
  - `operation` — String, Optional/Computed (default `EQ`)
  - `complex` — Bool, Optional/Computed
  - `ignore_case` — Bool, Optional/Computed
  - `match_mode` — String, Optional/Computed
  - `filter_string` — String, Optional

## Implementation notes

- Adopt-only lifecycle: Create reads the existing config and applies any diff via PUT. Delete is a no-op (warns via Terraform diagnostic).
- Import: `terraform import sailpoint_source_correlation_config.ad <source-id>`
- Uses `RequiresReplace` on `source_id` — correlation configs are inherently bound to a single source.

## Test plan

- [x] `make build` — compiles cleanly
- [x] `make lint` — 0 issues
- [x] `make test` — all existing unit tests pass
- [ ] Acceptance tests: `TF_ACC=1 go test -run TestAccSourceCorrelationConfig -timeout 120s` (requires live ISC tenant)
- [ ] Verify adopt creates correct state without API write when plan matches server state
- [ ] Verify update issues PUT on assignment change
- [ ] Verify delete is a no-op
- [ ] Verify import round-trip

## Anonymization checklist

- [x] No real tenant IDs, source IDs, identity IDs
- [x] No client or company names
- [x] Examples use generic attribute names (`sAMAccountName`, `uid`) consistent with ISC documentation