### PR TITLE
feat(resource): add sailpoint_source_aggregation_schedule

### DIFF
--- a/examples/resources/sailpoint_source_aggregation_schedule/resource.tf
+++ b/examples/resources/sailpoint_source_aggregation_schedule/resource.tf
@@ -1,0 +1,73 @@
+# Schedule account aggregation for an existing source to run on weekday mornings.
+# Requires the parent sailpoint_source to exist first.
+resource "sailpoint_source_aggregation_schedule" "accounts_nightly" {
+  source_id     = "REPLACE_WITH_SOURCE_ID"
+  schedule_type = "ACCOUNTS"
+
+  schedule = {
+    type = "WEEKLY"
+
+    hours = {
+      type   = "LIST"
+      values = ["2"] # 02:00 UTC
+    }
+
+    days = {
+      type   = "LIST"
+      values = ["MON", "TUE", "WED", "THU", "FRI"]
+    }
+
+    time_zone_id = "UTC"
+  }
+
+  enable_threshold = false
+}
+
+# Entitlement aggregation on Sunday nights with thresholding enabled.
+# If more than 20% of entitlements change in a single run, the aggregation
+# is paused and requires manual review in the SailPoint UI.
+resource "sailpoint_source_aggregation_schedule" "entitlements_weekly" {
+  source_id     = "REPLACE_WITH_SOURCE_ID"
+  schedule_type = "ENTITLEMENTS"
+
+  schedule = {
+    type = "WEEKLY"
+
+    hours = {
+      type   = "LIST"
+      values = ["1"] # 01:00 UTC
+    }
+
+    days = {
+      type   = "LIST"
+      values = ["SUN"]
+    }
+
+    time_zone_id = "UTC"
+  }
+
+  enable_threshold = true
+  threshold        = 20
+}
+
+# Daily account aggregation — no days component needed for DAILY type.
+resource "sailpoint_source_aggregation_schedule" "accounts_daily" {
+  source_id     = "REPLACE_WITH_SOURCE_ID"
+  schedule_type = "ACCOUNTS"
+
+  schedule = {
+    type = "DAILY"
+
+    hours = {
+      type   = "LIST"
+      values = ["4"] # 04:00 UTC
+    }
+
+    time_zone_id = "America/Chicago"
+  }
+
+  enable_threshold = false
+}
+
+# Import an existing schedule that was configured outside Terraform:
+#   terraform import sailpoint_source_aggregation_schedule.accounts_nightly REPLACE_WITH_SOURCE_ID/ACCOUNTS

--- a/internal/client/source_aggregation_schedules.go
+++ b/internal/client/source_aggregation_schedules.go
@@ -1,0 +1,363 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	sourceScheduleEndpointList   = "/v2025/sources/{sourceId}/schedules"
+	sourceScheduleEndpointGet    = "/v2025/sources/{sourceId}/schedules/{scheduleType}"
+	sourceScheduleEndpointCreate = "/v2025/sources/{sourceId}/schedules"
+	sourceScheduleEndpointUpdate = "/v2025/sources/{sourceId}/schedules/{scheduleType}"
+	sourceScheduleEndpointDelete = "/v2025/sources/{sourceId}/schedules/{scheduleType}"
+)
+
+// ScheduleHoursAPI represents the hours component of an aggregation schedule.
+type ScheduleHoursAPI struct {
+	Type     string   `json:"type"`
+	Values   []string `json:"values,omitempty"`
+	Interval *int64   `json:"interval,omitempty"`
+}
+
+// ScheduleDaysAPI represents the days component of an aggregation schedule.
+type ScheduleDaysAPI struct {
+	Type     string   `json:"type"`
+	Values   []string `json:"values,omitempty"`
+	Interval *int64   `json:"interval,omitempty"`
+}
+
+// ScheduleMonthsAPI represents the months component of an aggregation schedule.
+type ScheduleMonthsAPI struct {
+	Type     string   `json:"type"`
+	Values   []string `json:"values,omitempty"`
+	Interval *int64   `json:"interval,omitempty"`
+}
+
+// ScheduleAPI represents the schedule timing configuration.
+type ScheduleAPI struct {
+	Type       string             `json:"type"`
+	Hours      ScheduleHoursAPI   `json:"hours"`
+	Days       *ScheduleDaysAPI   `json:"days,omitempty"`
+	Months     *ScheduleMonthsAPI `json:"months,omitempty"`
+	TimeZoneID *string            `json:"timeZoneId,omitempty"`
+}
+
+// SourceAggregationScheduleAPI represents a SailPoint source aggregation schedule from the API.
+type SourceAggregationScheduleAPI struct {
+	Type              string      `json:"type"`
+	Schedule          ScheduleAPI `json:"schedule"`
+	EnableThreshold   bool        `json:"enableThreshold"`
+	Threshold         *int64      `json:"threshold,omitempty"`
+	CredentialsInBody *bool       `json:"credentialsInBody,omitempty"`
+}
+
+// sourceScheduleErrorContext provides context for error messages.
+type sourceScheduleErrorContext struct {
+	Operation    string
+	SourceID     string
+	ScheduleType string
+	ResponseBody string
+}
+
+// ListSourceAggregationSchedules retrieves all aggregation schedules for a source.
+func (c *Client) ListSourceAggregationSchedules(ctx context.Context, sourceID string) ([]SourceAggregationScheduleAPI, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("source ID cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Listing source aggregation schedules", map[string]any{
+		"source_id": sourceID,
+	})
+
+	var schedules []SourceAggregationScheduleAPI
+
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&schedules).
+		SetPathParam("sourceId", sourceID).
+		Get(sourceScheduleEndpointList)
+
+	if resp != nil && resp.IsError() {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{Operation: "list", SourceID: sourceID, ResponseBody: string(resp.Bytes())},
+			nil,
+			resp.StatusCode(),
+		)
+	}
+
+	if err != nil {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{Operation: "list", SourceID: sourceID},
+			err,
+			0,
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully listed source aggregation schedules", map[string]any{
+		"source_id": sourceID,
+		"count":     len(schedules),
+	})
+
+	return schedules, nil
+}
+
+// GetSourceAggregationSchedule retrieves a specific aggregation schedule by type.
+func (c *Client) GetSourceAggregationSchedule(ctx context.Context, sourceID, scheduleType string) (*SourceAggregationScheduleAPI, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("source ID cannot be empty")
+	}
+
+	if scheduleType == "" {
+		return nil, fmt.Errorf("schedule type cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Getting source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	var schedule SourceAggregationScheduleAPI
+
+	resp, err := c.prepareRequest(ctx).
+		SetResult(&schedule).
+		SetPathParam("sourceId", sourceID).
+		SetPathParam("scheduleType", scheduleType).
+		Get(sourceScheduleEndpointGet)
+
+	if resp != nil && resp.IsError() {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{
+				Operation: "get", SourceID: sourceID, ScheduleType: scheduleType,
+				ResponseBody: string(resp.Bytes()),
+			},
+			nil,
+			resp.StatusCode(),
+		)
+	}
+
+	if err != nil {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{Operation: "get", SourceID: sourceID, ScheduleType: scheduleType},
+			err,
+			0,
+		)
+	}
+
+	tflog.Debug(ctx, "Successfully retrieved source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	return &schedule, nil
+}
+
+// CreateSourceAggregationSchedule creates a new aggregation schedule for a source.
+func (c *Client) CreateSourceAggregationSchedule(ctx context.Context, sourceID string, schedule *SourceAggregationScheduleAPI) (*SourceAggregationScheduleAPI, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("source ID cannot be empty")
+	}
+
+	if schedule == nil {
+		return nil, fmt.Errorf("schedule cannot be nil")
+	}
+
+	tflog.Debug(ctx, "Creating source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": schedule.Type,
+	})
+
+	var result SourceAggregationScheduleAPI
+
+	resp, err := c.prepareRequest(ctx).
+		SetBody(schedule).
+		SetResult(&result).
+		SetPathParam("sourceId", sourceID).
+		Post(sourceScheduleEndpointCreate)
+
+	if resp != nil && resp.IsError() {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{
+				Operation: "create", SourceID: sourceID, ScheduleType: schedule.Type,
+				ResponseBody: string(resp.Bytes()),
+			},
+			nil,
+			resp.StatusCode(),
+		)
+	}
+
+	if err != nil {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{Operation: "create", SourceID: sourceID, ScheduleType: schedule.Type},
+			err,
+			0,
+		)
+	}
+
+	tflog.Info(ctx, "Successfully created source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": result.Type,
+	})
+
+	return &result, nil
+}
+
+// UpdateSourceAggregationSchedule performs a full replacement (PUT) of an aggregation schedule.
+func (c *Client) UpdateSourceAggregationSchedule(ctx context.Context, sourceID, scheduleType string, schedule *SourceAggregationScheduleAPI) (*SourceAggregationScheduleAPI, error) {
+	if sourceID == "" {
+		return nil, fmt.Errorf("source ID cannot be empty")
+	}
+
+	if scheduleType == "" {
+		return nil, fmt.Errorf("schedule type cannot be empty")
+	}
+
+	if schedule == nil {
+		return nil, fmt.Errorf("schedule cannot be nil")
+	}
+
+	tflog.Debug(ctx, "Updating source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	var result SourceAggregationScheduleAPI
+
+	resp, err := c.prepareRequest(ctx).
+		SetBody(schedule).
+		SetResult(&result).
+		SetPathParam("sourceId", sourceID).
+		SetPathParam("scheduleType", scheduleType).
+		Put(sourceScheduleEndpointUpdate)
+
+	if resp != nil && resp.IsError() {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{
+				Operation: "update", SourceID: sourceID, ScheduleType: scheduleType,
+				ResponseBody: string(resp.Bytes()),
+			},
+			nil,
+			resp.StatusCode(),
+		)
+	}
+
+	if err != nil {
+		return nil, c.formatSourceScheduleError(
+			sourceScheduleErrorContext{Operation: "update", SourceID: sourceID, ScheduleType: scheduleType},
+			err,
+			0,
+		)
+	}
+
+	tflog.Info(ctx, "Successfully updated source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	return &result, nil
+}
+
+// DeleteSourceAggregationSchedule removes an aggregation schedule from a source.
+func (c *Client) DeleteSourceAggregationSchedule(ctx context.Context, sourceID, scheduleType string) error {
+	if sourceID == "" {
+		return fmt.Errorf("source ID cannot be empty")
+	}
+
+	if scheduleType == "" {
+		return fmt.Errorf("schedule type cannot be empty")
+	}
+
+	tflog.Debug(ctx, "Deleting source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	resp, err := c.prepareRequest(ctx).
+		SetPathParam("sourceId", sourceID).
+		SetPathParam("scheduleType", scheduleType).
+		Delete(sourceScheduleEndpointDelete)
+
+	if resp != nil && resp.IsError() {
+		if resp.StatusCode() == http.StatusNotFound {
+			tflog.Debug(ctx, "Source aggregation schedule not found, treating as already deleted", map[string]any{
+				"source_id":     sourceID,
+				"schedule_type": scheduleType,
+			})
+			return nil
+		}
+
+		return c.formatSourceScheduleError(
+			sourceScheduleErrorContext{
+				Operation: "delete", SourceID: sourceID, ScheduleType: scheduleType,
+				ResponseBody: string(resp.Bytes()),
+			},
+			nil,
+			resp.StatusCode(),
+		)
+	}
+
+	if err != nil {
+		return c.formatSourceScheduleError(
+			sourceScheduleErrorContext{Operation: "delete", SourceID: sourceID, ScheduleType: scheduleType},
+			err,
+			0,
+		)
+	}
+
+	tflog.Info(ctx, "Successfully deleted source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	return nil
+}
+
+// formatSourceScheduleError formats errors with appropriate context for aggregation schedule operations.
+func (c *Client) formatSourceScheduleError(errCtx sourceScheduleErrorContext, err error, statusCode int) error {
+	var baseMsg string
+
+	if errCtx.ScheduleType != "" {
+		baseMsg = fmt.Sprintf("failed to %s aggregation schedule %q for source %q",
+			errCtx.Operation, errCtx.ScheduleType, errCtx.SourceID)
+	} else {
+		baseMsg = fmt.Sprintf("failed to %s aggregation schedules for source %q",
+			errCtx.Operation, errCtx.SourceID)
+	}
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", baseMsg, err)
+	}
+
+	if statusCode != 0 {
+		detail := ""
+		if errCtx.ResponseBody != "" {
+			detail = fmt.Sprintf(" - response: %s", errCtx.ResponseBody)
+		}
+
+		switch statusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("%s: invalid request (400)%s", baseMsg, detail)
+		case http.StatusUnauthorized:
+			return fmt.Errorf("%s: authentication failed (401)%s", baseMsg, detail)
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (403)%s", baseMsg, detail)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: %w", baseMsg, ErrNotFound)
+		case http.StatusConflict:
+			return fmt.Errorf("%s: conflict (409)%s", baseMsg, detail)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("%s: rate limit exceeded (429)%s", baseMsg, detail)
+		case http.StatusInternalServerError:
+			return fmt.Errorf("%s: server error (500)%s", baseMsg, detail)
+		default:
+			return fmt.Errorf("%s: unexpected status code %d%s", baseMsg, statusCode, detail)
+		}
+	}
+
+	return fmt.Errorf("%s: unknown error", baseMsg)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/role"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/segment"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/source"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/source_aggregation_schedule"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/transform"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/workflow"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/services/workflow_trigger"
@@ -198,6 +199,7 @@ func (p *sailpointProvider) Resources(_ context.Context) []func() resource.Resou
 		source.NewSourceResource,
 		source.NewSourceSchemaResource,
 		source.NewSourceProvisioningPolicyResource,
+		source_aggregation_schedule.NewSourceAggregationScheduleResource,
 		transform.NewTransformResource,
 		workflow.NewWorkflowResource,
 		workflow_trigger.NewWorkflowTriggerResource,

--- a/internal/services/source_aggregation_schedule/source_aggregation_schedule_model.go
+++ b/internal/services/source_aggregation_schedule/source_aggregation_schedule_model.go
@@ -1,0 +1,281 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source_aggregation_schedule
+
+import (
+	"context"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// scheduleTimeUnitModel maps the hours/days/months sub-objects.
+type scheduleTimeUnitModel struct {
+	Type     types.String `tfsdk:"type"`
+	Values   types.List   `tfsdk:"values"`
+	Interval types.Int64  `tfsdk:"interval"`
+}
+
+// scheduleTimeUnitAttrTypes returns the attribute type map for scheduleTimeUnitModel.
+func scheduleTimeUnitAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"type":     types.StringType,
+		"values":   types.ListType{ElemType: types.StringType},
+		"interval": types.Int64Type,
+	}
+}
+
+// scheduleModel maps the schedule nested attribute.
+type scheduleModel struct {
+	Type       types.String `tfsdk:"type"`
+	Hours      types.Object `tfsdk:"hours"`
+	Days       types.Object `tfsdk:"days"`
+	Months     types.Object `tfsdk:"months"`
+	TimeZoneID types.String `tfsdk:"time_zone_id"`
+}
+
+// scheduleAttrTypes returns the attribute type map for scheduleModel.
+func scheduleAttrTypes() map[string]attr.Type {
+	timeUnitType := types.ObjectType{AttrTypes: scheduleTimeUnitAttrTypes()}
+	return map[string]attr.Type{
+		"type":         types.StringType,
+		"hours":        timeUnitType,
+		"days":         timeUnitType,
+		"months":       timeUnitType,
+		"time_zone_id": types.StringType,
+	}
+}
+
+// sourceAggregationScheduleModel is the Terraform state model for sailpoint_source_aggregation_schedule.
+type sourceAggregationScheduleModel struct {
+	ID                types.String `tfsdk:"id"`
+	SourceID          types.String `tfsdk:"source_id"`
+	ScheduleType      types.String `tfsdk:"schedule_type"`
+	Schedule          types.Object `tfsdk:"schedule"`
+	EnableThreshold   types.Bool   `tfsdk:"enable_threshold"`
+	Threshold         types.Int64  `tfsdk:"threshold"`
+	CredentialsInBody types.Bool   `tfsdk:"credentials_in_body"`
+}
+
+// timeUnitFromAPI converts a ScheduleHoursAPI-like struct to a types.Object.
+func timeUnitFromAPI(ctx context.Context, apiType string, apiValues []string, apiInterval *int64) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	valList, d := types.ListValueFrom(ctx, types.StringType, apiValues)
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(scheduleTimeUnitAttrTypes()), diags
+	}
+
+	interval := types.Int64Null()
+	if apiInterval != nil {
+		interval = types.Int64Value(*apiInterval)
+	}
+
+	obj, d := types.ObjectValue(scheduleTimeUnitAttrTypes(), map[string]attr.Value{
+		"type":     types.StringValue(apiType),
+		"values":   valList,
+		"interval": interval,
+	})
+	diags.Append(d...)
+	return obj, diags
+}
+
+// FromAPI populates the Terraform model from the API response.
+func (m *sourceAggregationScheduleModel) FromAPI(ctx context.Context, sourceID string, api *client.SourceAggregationScheduleAPI) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.ID = types.StringValue(sourceID + "/" + api.Type)
+	m.SourceID = types.StringValue(sourceID)
+	m.ScheduleType = types.StringValue(api.Type)
+	m.EnableThreshold = types.BoolValue(api.EnableThreshold)
+
+	if api.Threshold != nil {
+		m.Threshold = types.Int64Value(*api.Threshold)
+	} else {
+		m.Threshold = types.Int64Null()
+	}
+
+	if api.CredentialsInBody != nil {
+		m.CredentialsInBody = types.BoolValue(*api.CredentialsInBody)
+	} else {
+		m.CredentialsInBody = types.BoolNull()
+	}
+
+	// Map hours
+	hoursObj, d := timeUnitFromAPI(ctx, api.Schedule.Hours.Type, api.Schedule.Hours.Values, api.Schedule.Hours.Interval)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Map days (optional)
+	daysObj := types.ObjectNull(scheduleTimeUnitAttrTypes())
+	if api.Schedule.Days != nil {
+		daysObj, d = timeUnitFromAPI(ctx, api.Schedule.Days.Type, api.Schedule.Days.Values, api.Schedule.Days.Interval)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+	}
+
+	// Map months (optional)
+	monthsObj := types.ObjectNull(scheduleTimeUnitAttrTypes())
+	if api.Schedule.Months != nil {
+		monthsObj, d = timeUnitFromAPI(ctx, api.Schedule.Months.Type, api.Schedule.Months.Values, api.Schedule.Months.Interval)
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+	}
+
+	// Map time_zone_id (optional)
+	tzID := types.StringNull()
+	if api.Schedule.TimeZoneID != nil {
+		tzID = types.StringValue(*api.Schedule.TimeZoneID)
+	}
+
+	schedObj, d := types.ObjectValue(scheduleAttrTypes(), map[string]attr.Value{
+		"type":         types.StringValue(api.Schedule.Type),
+		"hours":        hoursObj,
+		"days":         daysObj,
+		"months":       monthsObj,
+		"time_zone_id": tzID,
+	})
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	m.Schedule = schedObj
+	return diags
+}
+
+// timeUnitToAPI extracts an API hours/days/months struct from a types.Object.
+// Returns nil if the object is null or unknown.
+func timeUnitToAPI(ctx context.Context, obj types.Object) (*struct {
+	Type     string
+	Values   []string
+	Interval *int64
+}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if obj.IsNull() || obj.IsUnknown() {
+		return nil, diags
+	}
+
+	var m scheduleTimeUnitModel
+	diags.Append(obj.As(ctx, &m, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	var values []string
+	diags.Append(m.Values.ElementsAs(ctx, &values, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	var interval *int64
+	if !m.Interval.IsNull() && !m.Interval.IsUnknown() {
+		v := m.Interval.ValueInt64()
+		interval = &v
+	}
+
+	result := &struct {
+		Type     string
+		Values   []string
+		Interval *int64
+	}{
+		Type:     m.Type.ValueString(),
+		Values:   values,
+		Interval: interval,
+	}
+	return result, diags
+}
+
+// ToAPI converts the Terraform model to the API request body.
+func (m *sourceAggregationScheduleModel) ToAPI(ctx context.Context) (*client.SourceAggregationScheduleAPI, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var sched scheduleModel
+	diags.Append(m.Schedule.As(ctx, &sched, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Hours (required)
+	hoursRaw, d := timeUnitToAPI(ctx, sched.Hours)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	hours := client.ScheduleHoursAPI{}
+	if hoursRaw != nil {
+		hours.Type = hoursRaw.Type
+		hours.Values = hoursRaw.Values
+		hours.Interval = hoursRaw.Interval
+	}
+
+	apiSchedule := client.ScheduleAPI{
+		Type:  sched.Type.ValueString(),
+		Hours: hours,
+	}
+
+	// Days (optional)
+	daysRaw, d := timeUnitToAPI(ctx, sched.Days)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if daysRaw != nil {
+		apiSchedule.Days = &client.ScheduleDaysAPI{
+			Type:     daysRaw.Type,
+			Values:   daysRaw.Values,
+			Interval: daysRaw.Interval,
+		}
+	}
+
+	// Months (optional)
+	monthsRaw, d := timeUnitToAPI(ctx, sched.Months)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if monthsRaw != nil {
+		apiSchedule.Months = &client.ScheduleMonthsAPI{
+			Type:     monthsRaw.Type,
+			Values:   monthsRaw.Values,
+			Interval: monthsRaw.Interval,
+		}
+	}
+
+	// TimeZoneID (optional)
+	if !sched.TimeZoneID.IsNull() && !sched.TimeZoneID.IsUnknown() {
+		tz := sched.TimeZoneID.ValueString()
+		apiSchedule.TimeZoneID = &tz
+	}
+
+	api := &client.SourceAggregationScheduleAPI{
+		Type:            m.ScheduleType.ValueString(),
+		Schedule:        apiSchedule,
+		EnableThreshold: m.EnableThreshold.ValueBool(),
+	}
+
+	if !m.Threshold.IsNull() && !m.Threshold.IsUnknown() {
+		v := m.Threshold.ValueInt64()
+		api.Threshold = &v
+	}
+
+	if !m.CredentialsInBody.IsNull() && !m.CredentialsInBody.IsUnknown() {
+		v := m.CredentialsInBody.ValueBool()
+		api.CredentialsInBody = &v
+	}
+
+	return api, diags
+}

--- a/internal/services/source_aggregation_schedule/source_aggregation_schedule_resource.go
+++ b/internal/services/source_aggregation_schedule/source_aggregation_schedule_resource.go
@@ -1,0 +1,387 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package source_aggregation_schedule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &sourceAggregationScheduleResource{}
+	_ resource.ResourceWithConfigure   = &sourceAggregationScheduleResource{}
+	_ resource.ResourceWithImportState = &sourceAggregationScheduleResource{}
+)
+
+type sourceAggregationScheduleResource struct {
+	client *client.Client
+}
+
+// NewSourceAggregationScheduleResource creates a new resource for Source Aggregation Schedule.
+func NewSourceAggregationScheduleResource() resource.Resource {
+	return &sourceAggregationScheduleResource{}
+}
+
+// Metadata implements resource.Resource.
+func (r *sourceAggregationScheduleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_source_aggregation_schedule"
+}
+
+// Configure implements resource.ResourceWithConfigure.
+func (r *sourceAggregationScheduleResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	c, diags := common.ConfigureClient(ctx, req.ProviderData, "source aggregation schedule resource")
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = c
+}
+
+// timeUnitSchema returns the nested attribute schema for hours, days, and months.
+func timeUnitSchema(description string, required bool) schema.SingleNestedAttribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: description,
+		Required:            required,
+		Optional:            !required,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The type of schedule unit. Valid values: `DAILY`, `WEEKLY`, `MONTHLY`, `CALENDAR`, `LIST`, `RANGE`.",
+				Required:            true,
+			},
+			"values": schema.ListAttribute{
+				MarkdownDescription: "The list of values for the schedule unit (e.g. `[\"MON\", \"WED\", \"FRI\"]` for days, `[\"3\"]` for hour 3 AM).",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"interval": schema.Int64Attribute{
+				MarkdownDescription: "The interval for RANGE-type schedules (e.g. every N days).",
+				Optional:            true,
+				Computed:            true,
+			},
+		},
+	}
+}
+
+// Schema implements resource.Resource.
+func (r *sourceAggregationScheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a SailPoint source aggregation schedule.",
+		MarkdownDescription: "Manages a SailPoint source aggregation schedule. " +
+			"Aggregation schedules determine when a source performs account and entitlement aggregations. " +
+			"Each source supports up to two schedule types: `ACCOUNTS` and `ENTITLEMENTS`.\n\n" +
+			"The resource ID is a composite of `<source_id>/<schedule_type>`. " +
+			"To import: `terraform import sailpoint_source_aggregation_schedule.example <source_id>/<schedule_type>`.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The composite resource ID (`<source_id>/<schedule_type>`). Computed by the provider.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"source_id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the source this schedule belongs to. Changing this forces a new resource.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"schedule_type": schema.StringAttribute{
+				MarkdownDescription: "The type of aggregation schedule. Valid values: `ACCOUNTS`, `ENTITLEMENTS`. Changing this forces a new resource.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"schedule": schema.SingleNestedAttribute{
+				MarkdownDescription: "The timing configuration for this aggregation schedule.",
+				Required:            true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{
+						MarkdownDescription: "The schedule recurrence type. Valid values: `DAILY`, `WEEKLY`, `MONTHLY`, `CALENDAR`.",
+						Required:            true,
+					},
+					"hours": timeUnitSchema(
+						"The hours component of the schedule — specifies the hour(s) of day when the aggregation runs.",
+						true,
+					),
+					"days": timeUnitSchema(
+						"The days component of the schedule — specifies the day(s) of week or month when the aggregation runs. Required for `WEEKLY` and `MONTHLY` schedules.",
+						false,
+					),
+					"months": timeUnitSchema(
+						"The months component of the schedule — specifies the month(s) when the aggregation runs. Required for `CALENDAR` schedules.",
+						false,
+					),
+					"time_zone_id": schema.StringAttribute{
+						MarkdownDescription: "The IANA time zone identifier for the schedule (e.g. `UTC`, `America/Chicago`). Defaults to `UTC` when not specified.",
+						Optional:            true,
+						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"enable_threshold": schema.BoolAttribute{
+				MarkdownDescription: "When `true`, enables delta aggregation thresholding. If the number of accounts or entitlements changed exceeds the `threshold` percentage, the aggregation is paused for review.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"threshold": schema.Int64Attribute{
+				MarkdownDescription: "The percentage threshold for delta aggregation. Only meaningful when `enable_threshold` is `true`.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"credentials_in_body": schema.BoolAttribute{
+				MarkdownDescription: "Whether to include credentials in the aggregation request body. Computed from the source configuration.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+// Create implements resource.Resource.
+func (r *sourceAggregationScheduleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan sourceAggregationScheduleModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := plan.SourceID.ValueString()
+	scheduleType := plan.ScheduleType.ValueString()
+
+	tflog.Debug(ctx, "Creating source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	apiBody, diags := plan.ToAPI(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, err := r.client.CreateSourceAggregationSchedule(ctx, sourceID, apiBody)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Creating SailPoint Source Aggregation Schedule",
+			fmt.Sprintf("Could not create aggregation schedule %q for source %q: %s",
+				scheduleType, sourceID, err.Error()),
+		)
+		return
+	}
+
+	var state sourceAggregationScheduleModel
+	resp.Diagnostics.Append(state.FromAPI(ctx, sourceID, result)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Successfully created SailPoint Source Aggregation Schedule resource", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+}
+
+// Read implements resource.Resource.
+func (r *sourceAggregationScheduleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state sourceAggregationScheduleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := state.SourceID.ValueString()
+	scheduleType := state.ScheduleType.ValueString()
+
+	tflog.Debug(ctx, "Reading source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	result, err := r.client.GetSourceAggregationSchedule(ctx, sourceID, scheduleType)
+	if err != nil {
+		if errors.Is(err, client.ErrNotFound) {
+			tflog.Info(ctx, "Source aggregation schedule not found, removing from state", map[string]any{
+				"source_id":     sourceID,
+				"schedule_type": scheduleType,
+			})
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Reading SailPoint Source Aggregation Schedule",
+			fmt.Sprintf("Could not read aggregation schedule %q for source %q: %s",
+				scheduleType, sourceID, err.Error()),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(state.FromAPI(ctx, sourceID, result)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Successfully read SailPoint Source Aggregation Schedule resource", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+}
+
+// Update implements resource.Resource.
+func (r *sourceAggregationScheduleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan sourceAggregationScheduleModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state sourceAggregationScheduleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := state.SourceID.ValueString()
+	scheduleType := state.ScheduleType.ValueString()
+
+	tflog.Debug(ctx, "Updating source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	apiBody, diags := plan.ToAPI(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	result, err := r.client.UpdateSourceAggregationSchedule(ctx, sourceID, scheduleType, apiBody)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating SailPoint Source Aggregation Schedule",
+			fmt.Sprintf("Could not update aggregation schedule %q for source %q: %s",
+				scheduleType, sourceID, err.Error()),
+		)
+		return
+	}
+
+	var newState sourceAggregationScheduleModel
+	resp.Diagnostics.Append(newState.FromAPI(ctx, sourceID, result)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Successfully updated SailPoint Source Aggregation Schedule resource", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+}
+
+// Delete implements resource.Resource.
+func (r *sourceAggregationScheduleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state sourceAggregationScheduleModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	sourceID := state.SourceID.ValueString()
+	scheduleType := state.ScheduleType.ValueString()
+
+	tflog.Debug(ctx, "Deleting source aggregation schedule", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+
+	err := r.client.DeleteSourceAggregationSchedule(ctx, sourceID, scheduleType)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting SailPoint Source Aggregation Schedule",
+			fmt.Sprintf("Could not delete aggregation schedule %q for source %q: %s",
+				scheduleType, sourceID, err.Error()),
+		)
+		return
+	}
+
+	tflog.Info(ctx, "Successfully deleted SailPoint Source Aggregation Schedule resource", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+}
+
+// ImportState implements resource.ResourceWithImportState.
+// Import format: source_id/schedule_type (e.g. abc123/ACCOUNTS).
+func (r *sourceAggregationScheduleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	tflog.Debug(ctx, "Importing source aggregation schedule resource", map[string]any{
+		"import_id": req.ID,
+	})
+
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID format: source_id/schedule_type (e.g. abc123/ACCOUNTS), got: %s", req.ID),
+		)
+		return
+	}
+
+	sourceID := parts[0]
+	scheduleType := parts[1]
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("source_id"), sourceID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("schedule_type"), scheduleType)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+
+	tflog.Info(ctx, "Successfully imported SailPoint Source Aggregation Schedule resource", map[string]any{
+		"source_id":     sourceID,
+		"schedule_type": scheduleType,
+	})
+}


### PR DESCRIPTION
## Summary

- Adds resource `sailpoint_source_aggregation_schedule` for managing SailPoint ISC source aggregation schedules via the v2025 API.
- Supports both `ACCOUNTS` and `ENTITLEMENTS` schedule types per source.
- Full CRUD with composite ID (`<source_id>/<schedule_type>`), `RequiresReplace` on both key fields, and import support.

Closes #123

## Upstream API

- `POST /v2025/sources/{sourceId}/schedules`
- `GET /v2025/sources/{sourceId}/schedules/{scheduleType}`
- `PUT /v2025/sources/{sourceId}/schedules/{scheduleType}`
- `DELETE /v2025/sources/{sourceId}/schedules/{scheduleType}`

## Schema

- `id` — String, Computed (composite `<source_id>/<schedule_type>`)
- `source_id` — String, Required, RequiresReplace
- `schedule_type` — String, Required, RequiresReplace (`ACCOUNTS` or `ENTITLEMENTS`)
- `schedule` — SingleNestedAttribute, Required
  - `type` — String, Required (`DAILY`, `WEEKLY`, `MONTHLY`, `CALENDAR`)
  - `hours` — SingleNestedAttribute, Required (`type`, `values`, `interval`)
  - `days` — SingleNestedAttribute, Optional (`type`, `values`, `interval`)
  - `months` — SingleNestedAttribute, Optional (`type`, `values`, `interval`)
  - `time_zone_id` — String, Optional/Computed (IANA timezone)
- `enable_threshold` — Bool, Optional/Computed
- `threshold` — Int64, Optional/Computed
- `credentials_in_body` — Bool, Optional/Computed

## Test plan

- [x] Unit tests (`make test`)
- [x] Lint (`make lint`)
- [ ] Acceptance tests: `TF_ACC=1 go test -run TestAccSourceAggregationSchedule -timeout 120s`
- [ ] Manual import round-trip: `terraform import sailpoint_source_aggregation_schedule.example <source_id>/ACCOUNTS`
- [ ] Example in `examples/resources/` plans cleanly

## Anonymization checklist

- [x] No real tenant IDs, source IDs, identity IDs
- [x] No client or company names
- [x] No internal hostnames, DNs, emails
- [x] Examples use `REPLACE_WITH_SOURCE_ID` placeholders