### PR TITLE
fix(workflow): add v0 → v1 state upgrader for workflowStepsType

### DIFF
--- a/internal/services/workflow/workflow_resource.go
+++ b/internal/services/workflow/workflow_resource.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &workflowResource{}
-	_ resource.ResourceWithConfigure   = &workflowResource{}
-	_ resource.ResourceWithImportState = &workflowResource{}
+	_ resource.Resource                 = &workflowResource{}
+	_ resource.ResourceWithConfigure    = &workflowResource{}
+	_ resource.ResourceWithImportState  = &workflowResource{}
+	_ resource.ResourceWithUpgradeState = &workflowResource{}
 )
 
 type workflowResource struct {
@@ -54,6 +55,11 @@ func (r *workflowResource) Configure(ctx context.Context, req resource.Configure
 // Schema implements resource.Resource.
 func (r *workflowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		// Version 1 introduced the workflowStepsType custom string type on
+		// definition.steps (provider 2.4.4, closes #90). State written by
+		// provider 2.4.3 or earlier is upgraded by the v0 → v1 state upgrader
+		// in workflow_state_upgrader.go (closes #114).
+		Version:             1,
 		Description:         "Manages a SailPoint Workflow.",
 		MarkdownDescription: "Manages a SailPoint Workflow. Workflows are custom automation scripts that respond to event triggers and perform a series of actions. The trigger is managed separately using the `sailpoint_workflow_trigger` resource.",
 		Attributes: map[string]schema.Attribute{
@@ -485,4 +491,14 @@ func (r *workflowResource) ImportState(ctx context.Context, req resource.ImportS
 	tflog.Info(ctx, "Successfully imported SailPoint Workflow resource", map[string]any{
 		"id": req.ID,
 	})
+}
+
+// UpgradeState implements resource.ResourceWithUpgradeState.
+func (r *workflowResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   priorWorkflowSchemaV0(),
+			StateUpgrader: upgradeWorkflowStateV0ToV1,
+		},
+	}
 }

--- a/internal/services/workflow/workflow_state_upgrader.go
+++ b/internal/services/workflow/workflow_state_upgrader.go
@@ -1,0 +1,195 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// workflowModelV0 mirrors workflowModel for state shape v0. Field set is
+// identical; the only on-the-wire difference is that definition.steps used
+// jsontypes.NormalizedType. The framework decodes prior state into this
+// struct via priorWorkflowSchemaV0.
+type workflowModelV0 struct {
+	ID             types.String         `tfsdk:"id"`
+	Name           types.String         `tfsdk:"name"`
+	Owner          types.Object         `tfsdk:"owner"`
+	Description    types.String         `tfsdk:"description"`
+	Definition     types.Object         `tfsdk:"definition"`
+	Trigger        jsontypes.Normalized `tfsdk:"trigger"`
+	Enabled        types.Bool           `tfsdk:"enabled"`
+	Created        types.String         `tfsdk:"created"`
+	Modified       types.String         `tfsdk:"modified"`
+	Creator        types.Object         `tfsdk:"creator"`
+	ModifiedBy     types.Object         `tfsdk:"modified_by"`
+	ExecutionCount types.Int32          `tfsdk:"execution_count"`
+	FailureCount   types.Int32          `tfsdk:"failure_count"`
+}
+
+// priorWorkflowSchemaV0 returns the workflow resource schema as it shipped
+// in provider 2.4.3. Frozen — do not edit when v1 evolves; v0 is a
+// historical artifact used only by the framework to decode existing state
+// during upgrade. The only attribute that differs from v1 is
+// definition.steps (jsontypes.NormalizedType vs. workflowStepsType).
+func priorWorkflowSchemaV0() *schema.Schema {
+	return &schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"description": schema.StringAttribute{
+				Optional: true,
+			},
+			"enabled": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
+			"trigger": schema.StringAttribute{
+				Computed:   true,
+				CustomType: jsontypes.NormalizedType{},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"modified": schema.StringAttribute{
+				Computed: true,
+			},
+			"creator": schema.SingleNestedAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"modified_by": schema.SingleNestedAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Computed: true},
+					"id":   schema.StringAttribute{Computed: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"execution_count": schema.Int32Attribute{
+				Computed: true,
+			},
+			"failure_count": schema.Int32Attribute{
+				Computed: true,
+			},
+			"owner": schema.SingleNestedAttribute{
+				Required: true,
+				Attributes: map[string]schema.Attribute{
+					"type": schema.StringAttribute{Required: true},
+					"id":   schema.StringAttribute{Required: true},
+					"name": schema.StringAttribute{Computed: true},
+				},
+			},
+			"definition": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"start": schema.StringAttribute{
+						Required: true,
+					},
+					"steps": schema.StringAttribute{
+						Required:   true,
+						CustomType: jsontypes.NormalizedType{},
+					},
+				},
+			},
+		},
+	}
+}
+
+// upgradeWorkflowStateV0ToV1 maps a v0 workflow state to v1. The only
+// on-the-wire change between v0 and v1 is the framework type identity of
+// definition.steps (jsontypes.NormalizedType → workflowStepsType). The
+// underlying string is preserved verbatim — this is a no-op cast at the
+// data level, but the framework requires an explicit upgrader because it
+// rejects type-identity mismatches when reading prior state.
+//
+// See #114: provider 2.4.4 introduced workflowStepsType without this
+// upgrader, breaking every plan/refresh on existing state until users
+// pinned back to 2.4.3.
+func upgradeWorkflowStateV0ToV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	var prior workflowModelV0
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	upgraded := workflowModel{
+		ID:             prior.ID,
+		Name:           prior.Name,
+		Owner:          prior.Owner,
+		Description:    prior.Description,
+		Trigger:        prior.Trigger,
+		Enabled:        prior.Enabled,
+		Created:        prior.Created,
+		Modified:       prior.Modified,
+		Creator:        prior.Creator,
+		ModifiedBy:     prior.ModifiedBy,
+		ExecutionCount: prior.ExecutionCount,
+		FailureCount:   prior.FailureCount,
+	}
+
+	// Re-emit definition with the v1 attr types: steps wrapped in
+	// workflowStepsValue. The underlying JSON string is unchanged.
+	if prior.Definition.IsNull() {
+		upgraded.Definition = types.ObjectNull(definitionAttrTypes)
+	} else if prior.Definition.IsUnknown() {
+		upgraded.Definition = types.ObjectUnknown(definitionAttrTypes)
+	} else {
+		priorAttrs := prior.Definition.Attributes()
+		startAttr, _ := priorAttrs["start"].(types.String)
+		stepsAttr, _ := priorAttrs["steps"].(jsontypes.Normalized)
+
+		defObj, d := types.ObjectValue(definitionAttrTypes, map[string]attr.Value{
+			"start": startAttr,
+			"steps": workflowStepsValue{Normalized: stepsAttr},
+		})
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		upgraded.Definition = defObj
+	}
+
+	tflog.Info(ctx, "Upgraded workflow state from v0 to v1", map[string]any{
+		"id":   upgraded.ID.ValueString(),
+		"name": upgraded.Name.ValueString(),
+	})
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &upgraded)...)
+}

--- a/internal/services/workflow/workflow_state_upgrader_test.go
+++ b/internal/services/workflow/workflow_state_upgrader_test.go
@@ -1,0 +1,228 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestUpgradeWorkflowStateV0ToV1 verifies the v0 → v1 state upgrade for a
+// realistic workflow state: same wire data, only the framework type
+// identity of definition.steps changes. Closes #114.
+func TestUpgradeWorkflowStateV0ToV1(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	v0Schema := *priorWorkflowSchemaV0()
+	v1Schema := getWorkflowResourceSchema(ctx)
+
+	stepsJSON := `{"step1":{"actionId":"sp:operator-success","type":"success"}}`
+
+	tests := map[string]struct {
+		raw                tftypes.Value
+		wantID             string
+		wantName           string
+		wantDefinitionNull bool
+		wantStepsString    string
+		wantStartString    string
+		wantEnabled        bool
+		wantHasOwner       bool
+		wantOwnerType      string
+		wantOwnerID        string
+	}{
+		"workflow with definition and owner": {
+			raw: tftypes.NewValue(v0Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
+				"id":              tftypes.NewValue(tftypes.String, "wf-123"),
+				"name":            tftypes.NewValue(tftypes.String, "example-workflow"),
+				"description":     tftypes.NewValue(tftypes.String, "test"),
+				"enabled":         tftypes.NewValue(tftypes.Bool, false),
+				"trigger":         tftypes.NewValue(tftypes.String, nil),
+				"created":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+				"modified":        tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+				"execution_count": tftypes.NewValue(tftypes.Number, 0),
+				"failure_count":   tftypes.NewValue(tftypes.Number, 0),
+				"creator":         tftypes.NewValue(creatorTftype(), nil),
+				"modified_by":     tftypes.NewValue(creatorTftype(), nil),
+				"owner": tftypes.NewValue(creatorTftype(), map[string]tftypes.Value{
+					"type": tftypes.NewValue(tftypes.String, "IDENTITY"),
+					"id":   tftypes.NewValue(tftypes.String, "owner-id"),
+					"name": tftypes.NewValue(tftypes.String, "Owner Name"),
+				}),
+				"definition": tftypes.NewValue(definitionV0Tftype(), map[string]tftypes.Value{
+					"start": tftypes.NewValue(tftypes.String, "step1"),
+					"steps": tftypes.NewValue(tftypes.String, stepsJSON),
+				}),
+			}),
+			wantID:          "wf-123",
+			wantName:        "example-workflow",
+			wantStepsString: stepsJSON,
+			wantStartString: "step1",
+			wantEnabled:     false,
+			wantHasOwner:    true,
+			wantOwnerType:   "IDENTITY",
+			wantOwnerID:     "owner-id",
+		},
+		"workflow without definition": {
+			raw: tftypes.NewValue(v0Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
+				"id":              tftypes.NewValue(tftypes.String, "wf-456"),
+				"name":            tftypes.NewValue(tftypes.String, "no-def"),
+				"description":     tftypes.NewValue(tftypes.String, nil),
+				"enabled":         tftypes.NewValue(tftypes.Bool, true),
+				"trigger":         tftypes.NewValue(tftypes.String, nil),
+				"created":         tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+				"modified":        tftypes.NewValue(tftypes.String, "2026-01-01T00:00:00Z"),
+				"execution_count": tftypes.NewValue(tftypes.Number, 0),
+				"failure_count":   tftypes.NewValue(tftypes.Number, 0),
+				"creator":         tftypes.NewValue(creatorTftype(), nil),
+				"modified_by":     tftypes.NewValue(creatorTftype(), nil),
+				"owner": tftypes.NewValue(creatorTftype(), map[string]tftypes.Value{
+					"type": tftypes.NewValue(tftypes.String, "IDENTITY"),
+					"id":   tftypes.NewValue(tftypes.String, "owner-2"),
+					"name": tftypes.NewValue(tftypes.String, nil),
+				}),
+				"definition": tftypes.NewValue(definitionV0Tftype(), nil),
+			}),
+			wantID:             "wf-456",
+			wantName:           "no-def",
+			wantDefinitionNull: true,
+			wantEnabled:        true,
+			wantHasOwner:       true,
+			wantOwnerType:      "IDENTITY",
+			wantOwnerID:        "owner-2",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := resource.UpgradeStateRequest{
+				State: &tfsdk.State{
+					Schema: v0Schema,
+					Raw:    tc.raw,
+				},
+			}
+			resp := &resource.UpgradeStateResponse{
+				State: tfsdk.State{
+					Schema: v1Schema,
+				},
+			}
+
+			upgradeWorkflowStateV0ToV1(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("upgrader returned diagnostics: %v", resp.Diagnostics)
+			}
+
+			var got workflowModel
+			diags := resp.State.Get(ctx, &got)
+			if diags.HasError() {
+				t.Fatalf("failed to decode upgraded state: %v", diags)
+			}
+
+			if got.ID.ValueString() != tc.wantID {
+				t.Errorf("ID: want %q, got %q", tc.wantID, got.ID.ValueString())
+			}
+			if got.Name.ValueString() != tc.wantName {
+				t.Errorf("Name: want %q, got %q", tc.wantName, got.Name.ValueString())
+			}
+			if got.Enabled.ValueBool() != tc.wantEnabled {
+				t.Errorf("Enabled: want %v, got %v", tc.wantEnabled, got.Enabled.ValueBool())
+			}
+
+			if tc.wantHasOwner {
+				ownerAttrs := got.Owner.Attributes()
+				if ownerAttrs == nil {
+					t.Fatalf("Owner attributes nil")
+				}
+				if ownerType, ok := ownerAttrs["type"].(stringer); !ok {
+					t.Errorf("Owner.type: not a string-like value, got %T", ownerAttrs["type"])
+				} else if ownerType.ValueString() != tc.wantOwnerType {
+					t.Errorf("Owner.type: want %q, got %q", tc.wantOwnerType, ownerType.ValueString())
+				}
+				if ownerID, ok := ownerAttrs["id"].(stringer); !ok {
+					t.Errorf("Owner.id: not a string-like value")
+				} else if ownerID.ValueString() != tc.wantOwnerID {
+					t.Errorf("Owner.id: want %q, got %q", tc.wantOwnerID, ownerID.ValueString())
+				}
+			}
+
+			if tc.wantDefinitionNull {
+				if !got.Definition.IsNull() {
+					t.Errorf("expected Definition to be null")
+				}
+				return
+			}
+
+			defAttrs := got.Definition.Attributes()
+			if defAttrs == nil {
+				t.Fatalf("Definition attributes nil")
+			}
+			startVal, ok := defAttrs["start"].(stringer)
+			if !ok {
+				t.Fatalf("Definition.start: not a string-like value")
+			}
+			if startVal.ValueString() != tc.wantStartString {
+				t.Errorf("Definition.start: want %q, got %q", tc.wantStartString, startVal.ValueString())
+			}
+
+			// Critical assertion: steps must be wrapped in workflowStepsValue
+			// (not jsontypes.Normalized) — that is the whole point of v1.
+			stepsVal, ok := defAttrs["steps"].(workflowStepsValue)
+			if !ok {
+				t.Fatalf("Definition.steps: want workflowStepsValue, got %T", defAttrs["steps"])
+			}
+			if stepsVal.ValueString() != tc.wantStepsString {
+				t.Errorf("Definition.steps content: want %q, got %q", tc.wantStepsString, stepsVal.ValueString())
+			}
+		})
+	}
+}
+
+// stringer is satisfied by both types.String and any custom string type
+// the framework wraps under attr.Value, so the test stays type-agnostic for
+// fields that may evolve.
+type stringer interface {
+	ValueString() string
+}
+
+// creatorTftype returns the tftypes.Object shape used by owner/creator/
+// modified_by in the v0 schema.
+func creatorTftype() tftypes.Object {
+	return tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"type": tftypes.String,
+			"id":   tftypes.String,
+			"name": tftypes.String,
+		},
+	}
+}
+
+// definitionV0Tftype returns the tftypes.Object shape for definition in v0.
+// Steps is a string at the wire level (jsontypes.NormalizedType is just a
+// string with semantic equality).
+func definitionV0Tftype() tftypes.Object {
+	return tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"start": tftypes.String,
+			"steps": tftypes.String,
+		},
+	}
+}
+
+// getWorkflowResourceSchema invokes the resource's Schema method and
+// returns the resulting schema (v1). Used by the upgrade test to set up
+// resp.State with the v1 schema as the framework would.
+func getWorkflowResourceSchema(ctx context.Context) schema.Schema {
+	r := &workflowResource{}
+	resp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, resp)
+	return resp.Schema
+}


### PR DESCRIPTION
## Summary

Fixes the regression introduced by 2.4.4 (#90) where any state written by provider `<= 2.4.3` fails the first `plan` / `refresh` after upgrading to 2.4.4 with:

```
Object Attribute Name (steps) Expected Type: workflow.workflowStepsType
Object Attribute Name (steps) Given Type:    jsontypes.NormalizedType
```

This change:

- Bumps `workflowResource` schema to `Version: 1`
- Adds `priorWorkflowSchemaV0()` — frozen snapshot of the 2.4.3 schema (only `definition.steps` differs: `jsontypes.NormalizedType` vs `workflowStepsType`)
- Adds `upgradeWorkflowStateV0ToV1()` — re-decodes `definition.steps` into `workflowStepsType`, preserves all other attributes verbatim. One-shot, idempotent.
- Adds `TestUpgradeWorkflowStateV0ToV1` with two table-driven cases (with definition+owner, without definition) using `tftypes` directly.

The upgrade is transparent — existing state is mutated in place on the next `refresh`, no user action required.

## Test plan

- [x] `go build ./...` — pass
- [x] `go vet ./...` — pass
- [x] `go test ./internal/services/workflow/...` — pass (full pkg, includes the 2.4.4 `TestWorkflowStepsValue_StringSemanticEquals` regression suite + the new upgrader test)
- [ ] Manual: pin provider 2.4.3, `tofu apply` a minimal `sailpoint_workflow`, bump provider constraint to this branch, `tofu init -upgrade && tofu plan` — expect clean plan (no errors, no diff).

Closes #114