### PR TITLE
fix: extend UseStateForUnknownUnlessSiblingChanges to all resources

### DIFF
--- a/internal/services/access_profile/access_profile_resource.go
+++ b/internal/services/access_profile/access_profile_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -52,7 +53,7 @@ func objectRefNestedAttr(desc string, required bool) schema.SingleNestedAttribut
 		"name": schema.StringAttribute{
 			Computed: true,
 			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
+				planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 			},
 		},
 	}
@@ -134,7 +135,7 @@ func (r *accessProfileResource) Schema(_ context.Context, _ resource.SchemaReque
 						"name": schema.StringAttribute{
 							Computed: true,
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 							},
 						},
 					},
@@ -155,7 +156,7 @@ func (r *accessProfileResource) Schema(_ context.Context, _ resource.SchemaReque
 						"name": schema.StringAttribute{
 							Computed: true,
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 							},
 						},
 					},

--- a/internal/services/entitlement/entitlement_resource.go
+++ b/internal/services/entitlement/entitlement_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -115,7 +116,7 @@ func (r *entitlementResource) Schema(_ context.Context, _ resource.SchemaRequest
 						MarkdownDescription: "Name of the owner identity. Server-resolved.",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 						},
 					},
 				},

--- a/internal/services/governance_group/governance_group_resource.go
+++ b/internal/services/governance_group/governance_group_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -66,7 +67,7 @@ func memberNestedAttr(required bool) schema.SetNestedAttribute {
 					MarkdownDescription: "Name of the member identity. Server-resolved.",
 					Computed:            true,
 					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
+						planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 					},
 				},
 			},
@@ -106,7 +107,7 @@ func (r *governanceGroupResource) Schema(_ context.Context, _ resource.SchemaReq
 					"name": schema.StringAttribute{
 						Computed: true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 						},
 					},
 				},

--- a/internal/services/identity_profile/identity_profile_resource.go
+++ b/internal/services/identity_profile/identity_profile_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -117,7 +118,7 @@ func (r *identityProfileResource) Schema(_ context.Context, _ resource.SchemaReq
 						MarkdownDescription: "The name of the authoritative source.",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 						},
 					},
 				},

--- a/internal/services/role/role_resource.go
+++ b/internal/services/role/role_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -57,7 +58,7 @@ func objectRefSingle(desc string, required bool) schema.SingleNestedAttribute {
 			"name": schema.StringAttribute{
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 				},
 			},
 		},
@@ -75,7 +76,7 @@ func objectRefSet(desc string) schema.SetNestedAttribute {
 				"name": schema.StringAttribute{
 					Computed: true,
 					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
+						planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 					},
 				},
 			},
@@ -160,7 +161,7 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 						"name": schema.StringAttribute{
 							Computed: true,
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 							},
 						},
 					},
@@ -223,13 +224,13 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 								"name": schema.StringAttribute{
 									Computed: true,
 									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
+										planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 									},
 								},
 								"alias_name": schema.StringAttribute{
 									Computed: true,
 									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.UseStateForUnknown(),
+										planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 									},
 								},
 							},

--- a/internal/services/segment/segment_resource.go
+++ b/internal/services/segment/segment_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -87,7 +88,7 @@ func (r *segmentResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						MarkdownDescription: "The name of the owner. Resolved by the server from the owner ID.",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							planmodifiers.UseStateForUnknownUnlessSiblingChanges("id"),
 						},
 					},
 				},


### PR DESCRIPTION
Closes #112.

## Summary

Audit + systematic remediation of the `UseStateForUnknownUnlessSiblingChanges("id")` pattern (introduced in #101 for `sailpoint_source`). Every server-resolved `name` inside a nested `{type, id, name}` object must use this modifier instead of the bare `stringplanmodifier.UseStateForUnknown()` — otherwise changing the sibling `id` freezes the stale `name` in the plan and triggers **"inconsistent result after apply"**.

## Resources fixed

| Resource | Fixed `name` fields |
|----------|---------------------|
| `sailpoint_entitlement` | `owner.name` |
| `sailpoint_identity_profile` | `authoritative_source.name` |
| `sailpoint_segment` | `owner.name` |
| `sailpoint_role` | `owner.name`, `access_profiles[*].name`, `entitlements[*].name`, `additional_owners[*].name`, `dimension_refs[*].name`, `membership.identities.name`, `membership.identities.alias_name` |
| `sailpoint_access_profile` | `owner.name`, `source.name`, `entitlements[*].name`, `additional_owners[*].name` |
| `sailpoint_governance_group` | `owner.name`, `members[*].name` |

## Re-audit note

`sailpoint_governance_group` (#126) was added **after** the original audit and carried the same bug; it is now included. The other post-audit resources were re-checked and are **not** affected:
- `sailpoint_source_correlation_config` — its only `name` is the top-level server-assigned name, not a sibling-`id` ref.
- `sailpoint_source_aggregation_schedule` — no `name` attribute.

## Out of scope (separate pre-existing gap)

`make generate` surfaces untracked docs for `governance_group`, `identity`, `source_correlation_config`, `source_aggregation_schedule` — their generating PRs (#126–#129) never committed the rendered docs, and the `generate` CI check (`git diff --exit-code`) is blind to untracked files. Tracked here for visibility; not addressed in this PR to keep it focused.

## Test plan

The repo doesn't exercise this path in acceptance tests (per the issue's out-of-scope), so verification is manual reproduction:
- [ ] On an existing resource, change `owner.id` to a different identity → `terraform plan` shows `owner.name` as *known after apply* (not the stale name)
- [ ] `terraform apply` succeeds without "inconsistent result after apply"
- [ ] No-op plan with unchanged `owner.id` → `owner.name` stays stable (reused from state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
