### PR TITLE
feat(jsonpath): bracket-quoted keys + PreservePathsInJSON helper

### DIFF
--- a/internal/common/jsonpath/jsonpath.go
+++ b/internal/common/jsonpath/jsonpath.go
@@ -2,17 +2,22 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Package jsonpath implements a minimal subset of JSONPath for preserving
-// server-managed fields in connector_attributes arrays.
+// server-managed fields in JSON attributes.
 //
 // Supported syntax:
 //
 //	$.key
 //	$.key.nested
-//	$.key[N].field   (N is a non-negative integer index)
-//	$.key[*].field   (wildcard: all array elements)
+//	$.key[N].field          (N is a non-negative integer index)
+//	$.key[*].field          (wildcard: all array elements)
+//	$.key['obj key']        (bracket-quoted, single quotes: for keys containing spaces or dots)
+//	$.key["obj key"]        (bracket-quoted, double quotes: equivalent double-quote variant)
+//	$['obj key']            (bracket-quoted key directly after root '$')
+//	$['outer']['inner']     (chained bracket-quoted keys)
 package jsonpath
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -66,10 +71,20 @@ func Parse(path string) ([]segment, error) {
 			rest = rest[end+1:]
 			if inner == "*" {
 				segs = append(segs, segment{kind: segWildcard})
+			} else if len(inner) >= 2 && (inner[0] == '\'' || inner[0] == '"') {
+				quote := inner[0]
+				if inner[len(inner)-1] != quote {
+					return nil, fmt.Errorf("mismatched quotes in bracket key in path: %q", path)
+				}
+				key := inner[1 : len(inner)-1]
+				if key == "" {
+					return nil, fmt.Errorf("empty bracket-quoted key in path: %q", path)
+				}
+				segs = append(segs, segment{kind: segKey, key: key})
 			} else {
 				idx, err := strconv.Atoi(inner)
 				if err != nil || idx < 0 {
-					return nil, fmt.Errorf("invalid index %q in path: %q (expected non-negative integer or *)", inner, path)
+					return nil, fmt.Errorf("invalid index %q in path: %q (expected non-negative integer, *, 'key', or \"key\")", inner, path)
 				}
 				segs = append(segs, segment{kind: segIndex, idx: idx})
 			}
@@ -103,6 +118,30 @@ func PreservePaths(merged, serverAttrs map[string]interface{}, paths []string) e
 		preserveNode(merged, serverAttrs, segs)
 	}
 	return nil
+}
+
+// PreservePathsInJSON unmarshals mergedJSON and priorJSON, re-injects the values
+// from priorJSON into mergedJSON at each path (using PreservePaths), and
+// re-marshals the result. Paths absent from priorJSON are silently skipped.
+// Returns the merged JSON string, or an error if either input is invalid JSON or
+// a path cannot be parsed.
+func PreservePathsInJSON(mergedJSON, priorJSON string, paths []string) (string, error) {
+	var merged map[string]interface{}
+	if err := json.Unmarshal([]byte(mergedJSON), &merged); err != nil {
+		return "", fmt.Errorf("unmarshal merged JSON: %w", err)
+	}
+	var prior map[string]interface{}
+	if err := json.Unmarshal([]byte(priorJSON), &prior); err != nil {
+		return "", fmt.Errorf("unmarshal prior JSON: %w", err)
+	}
+	if err := PreservePaths(merged, prior, paths); err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return "", fmt.Errorf("marshal merged JSON: %w", err)
+	}
+	return string(out), nil
 }
 
 // preserveNode walks merged and server in lock-step following segs,

--- a/internal/common/jsonpath/jsonpath_test.go
+++ b/internal/common/jsonpath/jsonpath_test.go
@@ -4,6 +4,8 @@
 package jsonpath
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -70,6 +72,46 @@ func TestParse_valid(t *testing.T) {
 			wantKeys:  []string{"a", "b", "c"},
 			wantIdxs:  []int{0, 0, 0},
 		},
+		// Bracket-quoted keys (single quotes).
+		{
+			path:      "$['foo']",
+			wantKinds: []segKind{segKey},
+			wantKeys:  []string{"foo"},
+			wantIdxs:  []int{0},
+		},
+		{
+			path:      "$['key with spaces']",
+			wantKinds: []segKind{segKey},
+			wantKeys:  []string{"key with spaces"},
+			wantIdxs:  []int{0},
+		},
+		// Bracket-quoted keys (double quotes).
+		{
+			path:      "$[\"foo\"]",
+			wantKinds: []segKind{segKey},
+			wantKeys:  []string{"foo"},
+			wantIdxs:  []int{0},
+		},
+		{
+			path:      "$[\"key with spaces\"]",
+			wantKinds: []segKind{segKey},
+			wantKeys:  []string{"key with spaces"},
+			wantIdxs:  []int{0},
+		},
+		// Mixed: dot-key prefix followed by bracket-quoted key.
+		{
+			path:      "$.steps['Create Ticket'].attr",
+			wantKinds: []segKind{segKey, segKey, segKey},
+			wantKeys:  []string{"steps", "Create Ticket", "attr"},
+			wantIdxs:  []int{0, 0, 0},
+		},
+		// Chained bracket-quoted keys.
+		{
+			path:      "$['outer']['inner']",
+			wantKinds: []segKind{segKey, segKey},
+			wantKeys:  []string{"outer", "inner"},
+			wantIdxs:  []int{0, 0},
+		},
 	}
 
 	for _, tc := range cases {
@@ -100,13 +142,16 @@ func TestParse_invalid(t *testing.T) {
 	cases := []struct {
 		path string
 	}{
-		{path: "foo"},            // no leading $
-		{path: "$"},              // no segments
-		{path: "$."},             // empty key
-		{path: "$.foo["},         // unclosed bracket
-		{path: "$.foo[-1].bar"},  // negative index
-		{path: "$.foo[abc].bar"}, // non-integer index
-		{path: "$!foo"},          // unexpected char
+		{path: "foo"},              // no leading $
+		{path: "$"},                // no segments
+		{path: "$."},               // empty key
+		{path: "$.foo["},           // unclosed bracket
+		{path: "$.foo[-1].bar"},    // negative index
+		{path: "$.foo[abc].bar"},   // non-integer, non-quoted index
+		{path: "$!foo"},            // unexpected char
+		{path: "$['']"},            // empty single-quoted key
+		{path: "$[\"\"]"},          // empty double-quoted key
+		{path: "$['mismatched\"]"}, // mismatched quotes (opens ', closes ")
 	}
 
 	for _, tc := range cases {
@@ -278,6 +323,133 @@ func TestPreservePaths_invalidPath(t *testing.T) {
 	err := PreservePaths(merged, server, []string{"invalid-path"})
 	if err == nil {
 		t.Error("expected error for invalid path")
+	}
+}
+
+func TestPreservePathsInJSON(t *testing.T) {
+	cases := []struct {
+		name       string
+		mergedJSON string
+		priorJSON  string
+		paths      []string
+		wantJSON   string // expected result; use checkKey/checkMissing instead when order varies
+		wantErr    bool
+	}{
+		{
+			name:       "top-level key",
+			mergedJSON: `{"host":"ldap.example.com"}`,
+			priorJSON:  `{"host":"ldap.example.com","password":"secret"}`,
+			paths:      []string{"$.password"},
+			wantJSON:   `{"host":"ldap.example.com","password":"secret"}`,
+		},
+		{
+			name:       "nested key",
+			mergedJSON: `{"conn":{"host":"ldap.example.com"}}`,
+			priorJSON:  `{"conn":{"host":"ldap.example.com","password":"secret"}}`,
+			paths:      []string{"$.conn.password"},
+			wantJSON:   `{"conn":{"host":"ldap.example.com","password":"secret"}}`,
+		},
+		{
+			name:       "wildcard array",
+			mergedJSON: `{"items":[{"name":"a"},{"name":"b"}]}`,
+			priorJSON:  `{"items":[{"name":"a","token":"t1"},{"name":"b","token":"t2"}]}`,
+			paths:      []string{"$.items[*].token"},
+		},
+		{
+			name:       "bracket-quoted key with spaces",
+			mergedJSON: `{"steps":{"Create Ticket":{"type":"action"}}}`,
+			priorJSON:  `{"steps":{"Create Ticket":{"type":"action","refID":"abc"}}}`,
+			paths:      []string{"$.steps['Create Ticket'].refID"},
+			wantJSON:   `{"steps":{"Create Ticket":{"refID":"abc","type":"action"}}}`,
+		},
+		{
+			name:       "prior-missing path is no-op",
+			mergedJSON: `{"foo":"bar"}`,
+			priorJSON:  `{"foo":"bar"}`,
+			paths:      []string{"$.password"},
+			wantJSON:   `{"foo":"bar"}`,
+		},
+		{
+			name:       "invalid path error",
+			mergedJSON: `{"foo":"bar"}`,
+			priorJSON:  `{"foo":"bar"}`,
+			paths:      []string{"invalid-path"},
+			wantErr:    true,
+		},
+		{
+			name:       "invalid merged JSON error",
+			mergedJSON: `not-json`,
+			priorJSON:  `{}`,
+			paths:      []string{"$.foo"},
+			wantErr:    true,
+		},
+		{
+			name:       "invalid prior JSON error",
+			mergedJSON: `{}`,
+			priorJSON:  `not-json`,
+			paths:      []string{"$.foo"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PreservePathsInJSON(tc.mergedJSON, tc.priorJSON, tc.paths)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("PreservePathsInJSON(%q, %q, %v) expected error, got nil", tc.mergedJSON, tc.priorJSON, tc.paths)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PreservePathsInJSON unexpected error: %v", err)
+			}
+			if tc.wantJSON != "" {
+				// Normalise both through JSON round-trip to avoid key-ordering sensitivity.
+				var gotObj, wantObj interface{}
+				if e := json.Unmarshal([]byte(got), &gotObj); e != nil {
+					t.Fatalf("result is not valid JSON: %v", e)
+				}
+				if e := json.Unmarshal([]byte(tc.wantJSON), &wantObj); e != nil {
+					t.Fatalf("wantJSON is not valid JSON: %v", e)
+				}
+				gotNorm, gotMarshalErr := json.Marshal(gotObj)
+				if gotMarshalErr != nil {
+					t.Fatalf("marshal result: %v", gotMarshalErr)
+				}
+				wantNorm, wantMarshalErr := json.Marshal(wantObj)
+				if wantMarshalErr != nil {
+					t.Fatalf("marshal want: %v", wantMarshalErr)
+				}
+				if string(gotNorm) != string(wantNorm) {
+					t.Errorf("got  %s\nwant %s", gotNorm, wantNorm)
+				}
+			}
+			// For the wildcard case, verify element-level values directly.
+			if tc.name == "wildcard array" {
+				var obj map[string]interface{}
+				if e := json.Unmarshal([]byte(got), &obj); e != nil {
+					t.Fatalf("result is not valid JSON: %v", e)
+				}
+				items := mustArray(t, obj["items"], "items")
+				for i, wantToken := range []string{"t1", "t2"} {
+					elem := mustObject(t, items[i], fmt.Sprintf("items[%d]", i))
+					tokenAny, exists := elem["token"]
+					if !exists {
+						t.Errorf("items[%d].token missing", i)
+						continue
+					}
+					token, ok := tokenAny.(string)
+					if !ok {
+						t.Errorf("items[%d].token: expected string, got %T", i, tokenAny)
+						continue
+					}
+					if token != wantToken {
+						t.Errorf("items[%d].token = %q, want %q", i, token, wantToken)
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Foundation for #142 (provider-wide `ignore_json_changes`). **No resource wiring** — pure `internal/common/jsonpath` primitives, so there's no rework risk against the upcoming steps remodel.

- `Parse`: accept bracket-quoted object keys `['key']` / `["key"]` (keys with spaces or dots, e.g. workflow step names like `Create Ticket`). All existing syntax unchanged.
- Add `PreservePathsInJSON(mergedJSON, priorJSON, paths)` — a string-level wrapper over `PreservePaths` so resources can re-inject a practitioner's value at chosen paths inside a JSON-blob attribute.
- Table-driven tests for both (valid/invalid parses, keys with spaces, chained brackets, mismatched quotes; helper top-level/nested/wildcard/missing-path no-op/invalid-path).

Resource wiring lands in follow-ups; the workflow consumer ships with the steps remodel (#141), since its `ignore_json_changes` paths depend on that new typed-map structure.

Refs #142.
