### PR TITLE
feat(workflow): wire ignore_json_changes into the workflow resource

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -64,6 +64,7 @@ resource "sailpoint_workflow" "send_email" {
 - `definition` (Attributes) The workflow definition containing the steps to execute. If not specified, the workflow will have no definition. (see [below for nested schema](#nestedatt--definition))
 - `description` (String) The description of the workflow.
 - `enabled` (Boolean) Whether the workflow is enabled. Workflows cannot be created in an enabled state. Defaults to `false`.
+- `ignore_json_changes` (List of String) Paths inside JSON step fields whose server-minted drift the practitioner chooses to ignore (analogous to `ignore_changes`, but reaching inside JSON-string attributes). Each entry has the form `definition.steps['<step name>'].<field>.<json-path>` where `<field>` is one of `attributes`, `config`, or `catch` and `<json-path>` is a dotted path inside that JSON object (e.g. `param_oauth.refID`).
 
 ### Read-Only
 

--- a/examples/resources/sailpoint_workflow/http_request.tf
+++ b/examples/resources/sailpoint_workflow/http_request.tf
@@ -59,4 +59,12 @@ resource "sailpoint_workflow" "external_integration" {
   }
 
   enabled = false
+
+  # SailPoint mints internal reference IDs (e.g. param_oauth.refID) inside sp:http
+  # step attributes after creation. List those paths here so Terraform ignores the
+  # server-generated values and keeps the practitioner's placeholder in state.
+  ignore_json_changes = [
+    "definition.steps['Create Ticket'].attributes.param_oauth.refID",
+    "definition.steps['Create Ticket'].attributes.param_header.refID",
+  ]
 }

--- a/internal/services/workflow/workflow_data_source.go
+++ b/internal/services/workflow/workflow_data_source.go
@@ -22,6 +22,44 @@ var (
 	_ datasource.DataSourceWithConfigure = &workflowDataSource{}
 )
 
+// workflowDSModel is the data-source counterpart of workflowModel.
+// It is identical but omits ignore_json_changes (resource-only attribute).
+type workflowDSModel struct {
+	ID             types.String         `tfsdk:"id"`
+	Name           types.String         `tfsdk:"name"`
+	Owner          types.Object         `tfsdk:"owner"`
+	Description    types.String         `tfsdk:"description"`
+	Definition     types.Object         `tfsdk:"definition"`
+	Trigger        jsontypes.Normalized `tfsdk:"trigger"`
+	Enabled        types.Bool           `tfsdk:"enabled"`
+	Created        types.String         `tfsdk:"created"`
+	Modified       types.String         `tfsdk:"modified"`
+	Creator        types.Object         `tfsdk:"creator"`
+	ModifiedBy     types.Object         `tfsdk:"modified_by"`
+	ExecutionCount types.Int32          `tfsdk:"execution_count"`
+	FailureCount   types.Int32          `tfsdk:"failure_count"`
+}
+
+// workflowModelToDS converts a workflowModel to workflowDSModel, dropping fields
+// that are resource-only (ignore_json_changes).
+func workflowModelToDS(m workflowModel) workflowDSModel {
+	return workflowDSModel{
+		ID:             m.ID,
+		Name:           m.Name,
+		Owner:          m.Owner,
+		Description:    m.Description,
+		Definition:     m.Definition,
+		Trigger:        m.Trigger,
+		Enabled:        m.Enabled,
+		Created:        m.Created,
+		Modified:       m.Modified,
+		Creator:        m.Creator,
+		ModifiedBy:     m.ModifiedBy,
+		ExecutionCount: m.ExecutionCount,
+		FailureCount:   m.FailureCount,
+	}
+}
+
 type workflowDataSource struct {
 	client *client.Client
 }
@@ -238,14 +276,16 @@ func (d *workflowDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	// Map the response to the data source model
-	var state workflowModel
+	var m workflowModel
 	tflog.Debug(ctx, "Mapping SailPoint Workflow API response to data source model", map[string]any{
 		"id": id,
 	})
-	resp.Diagnostics.Append(state.FromAPI(ctx, *workflowResponse)...)
+	resp.Diagnostics.Append(m.FromAPI(ctx, *workflowResponse)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	state := workflowModelToDS(m)
 
 	// Set the state
 	tflog.Debug(ctx, "Setting state for workflow data source", map[string]any{

--- a/internal/services/workflow/workflow_ignore_json.go
+++ b/internal/services/workflow/workflow_ignore_json.go
@@ -1,0 +1,193 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/jsonpath"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// resolveIgnoreJSONPath parses a resource-rooted ignore_json_changes path of the form
+// "definition.steps['<step>'].<field>.<json-path>" into (stepName, field, inJSONPath).
+// field must be one of "attributes", "config", or "catch"; inJSONPath is used as "$.<inJSONPath>".
+func resolveIgnoreJSONPath(p string) (stepName, field, inJSONPath string, err error) {
+	const prefix = "definition.steps["
+	if !strings.HasPrefix(p, prefix) {
+		return "", "", "", fmt.Errorf("path %q must start with %q followed by a bracket-quoted step name", p, prefix)
+	}
+	rest := p[len(prefix):]
+
+	bracketEnd := strings.Index(rest, "]")
+	if bracketEnd < 0 {
+		return "", "", "", fmt.Errorf("path %q: unclosed '[' in step name", p)
+	}
+	inner := rest[:bracketEnd]
+	rest = rest[bracketEnd+1:]
+
+	if len(inner) < 2 {
+		return "", "", "", fmt.Errorf("path %q: step name must be bracket-quoted (e.g. ['My Step'])", p)
+	}
+	quote := inner[0]
+	if quote != '\'' && quote != '"' {
+		return "", "", "", fmt.Errorf("path %q: step name must be bracket-quoted with single or double quotes", p)
+	}
+	if inner[len(inner)-1] != quote {
+		return "", "", "", fmt.Errorf("path %q: mismatched quotes in step name", p)
+	}
+	stepName = inner[1 : len(inner)-1]
+	if stepName == "" {
+		return "", "", "", fmt.Errorf("path %q: step name must not be empty", p)
+	}
+
+	if !strings.HasPrefix(rest, ".") {
+		return "", "", "", fmt.Errorf("path %q: expected '.<field>' after step name", p)
+	}
+	rest = rest[1:]
+
+	dotIdx := strings.Index(rest, ".")
+	if dotIdx < 0 {
+		return "", "", "", fmt.Errorf("path %q: must specify an in-JSON path after the field (e.g. .attributes.param_oauth.refID)", p)
+	}
+	field = rest[:dotIdx]
+	rest = rest[dotIdx+1:]
+
+	switch field {
+	case "attributes", "config", "catch":
+	default:
+		return "", "", "", fmt.Errorf("path %q: field %q is not a JSON step field; must be one of: attributes, config, catch", p, field)
+	}
+
+	if rest == "" {
+		return "", "", "", fmt.Errorf("path %q: in-JSON path must not be empty", p)
+	}
+
+	if err := jsonpath.Validate("$." + rest); err != nil {
+		return "", "", "", fmt.Errorf("path %q: invalid in-JSON path %q: %w", p, "$."+rest, err)
+	}
+
+	return stepName, field, rest, nil
+}
+
+// applyIgnoreJSONChanges re-injects sourceModel values at each ignored path to suppress server-minted drift.
+// Pass plan as sourceModel on Create, prior state on Read/Update.
+// Groups by (stepName, field); steps or fields absent from sourceModel are silently skipped.
+func applyIgnoreJSONChanges(newModel *workflowModel, sourceModel *workflowModel, ignorePaths types.List) diag.Diagnostics {
+	if ignorePaths.IsNull() || ignorePaths.IsUnknown() || len(ignorePaths.Elements()) == 0 {
+		return nil
+	}
+
+	type groupKey struct{ step, field string }
+	grouped := make(map[groupKey][]string)
+
+	for _, elem := range ignorePaths.Elements() {
+		pathStr, ok := elem.(types.String)
+		if !ok || pathStr.IsNull() || pathStr.IsUnknown() {
+			continue
+		}
+		stepName, field, inJSONPath, err := resolveIgnoreJSONPath(pathStr.ValueString())
+		if err != nil {
+			continue // ValidateConfig already rejected malformed paths
+		}
+		k := groupKey{stepName, field}
+		grouped[k] = append(grouped[k], "$."+inJSONPath)
+	}
+
+	if len(grouped) == 0 {
+		return nil
+	}
+
+	if newModel.Definition.IsNull() || newModel.Definition.IsUnknown() {
+		return nil
+	}
+	if sourceModel.Definition.IsNull() || sourceModel.Definition.IsUnknown() {
+		return nil
+	}
+
+	newDefAttrs := newModel.Definition.Attributes()
+	newStepsMap, ok := newDefAttrs["steps"].(types.Map)
+	if !ok || newStepsMap.IsNull() || newStepsMap.IsUnknown() {
+		return nil
+	}
+
+	sourceDefAttrs := sourceModel.Definition.Attributes()
+	sourceStepsMap, ok := sourceDefAttrs["steps"].(types.Map)
+	if !ok || sourceStepsMap.IsNull() || sourceStepsMap.IsUnknown() {
+		return nil
+	}
+
+	newStepElems := newStepsMap.Elements()
+	sourceStepElems := sourceStepsMap.Elements()
+
+	modified := false
+
+	for k, paths := range grouped {
+		sourceStepVal, ok := sourceStepElems[k.step]
+		if !ok {
+			continue // step absent from source (e.g. brand-new step on create)
+		}
+		newStepVal, ok := newStepElems[k.step]
+		if !ok {
+			continue
+		}
+
+		sourceStep, ok := sourceStepVal.(types.Object)
+		if !ok {
+			continue
+		}
+		newStep, ok := newStepVal.(types.Object)
+		if !ok {
+			continue
+		}
+
+		sourceStepAttrs := sourceStep.Attributes()
+		newStepAttrs := newStep.Attributes()
+
+		sourceFieldVal, ok := sourceStepAttrs[k.field].(jsontypes.Normalized)
+		if !ok || sourceFieldVal.IsNull() || sourceFieldVal.IsUnknown() {
+			continue
+		}
+
+		newFieldVal, ok := newStepAttrs[k.field].(jsontypes.Normalized)
+		if !ok || newFieldVal.IsNull() || newFieldVal.IsUnknown() {
+			continue
+		}
+
+		merged, mergeErr := jsonpath.PreservePathsInJSON(newFieldVal.ValueString(), sourceFieldVal.ValueString(), paths)
+		if mergeErr != nil || merged == newFieldVal.ValueString() {
+			continue
+		}
+
+		newStepAttrs[k.field] = jsontypes.NewNormalizedValue(merged)
+
+		newStepObj, diags := types.ObjectValue(stepAttrTypes, newStepAttrs)
+		if diags.HasError() {
+			return diags
+		}
+		newStepElems[k.step] = newStepObj
+		modified = true
+	}
+
+	if !modified {
+		return nil
+	}
+
+	newStepsUpdated, diags := types.MapValue(types.ObjectType{AttrTypes: stepAttrTypes}, newStepElems)
+	if diags.HasError() {
+		return diags
+	}
+
+	newDefAttrs["steps"] = newStepsUpdated
+	newDefObj, diags := types.ObjectValue(definitionAttrTypes, newDefAttrs)
+	if diags.HasError() {
+		return diags
+	}
+
+	newModel.Definition = newDefObj
+	return nil
+}

--- a/internal/services/workflow/workflow_ignore_json_test.go
+++ b/internal/services/workflow/workflow_ignore_json_test.go
@@ -1,0 +1,348 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// mustListValue builds a types.List of strings for tests.
+func mustListValue(t *testing.T, elems []string) types.List {
+	t.Helper()
+	vals := make([]attr.Value, len(elems))
+	for i, s := range elems {
+		vals[i] = types.StringValue(s)
+	}
+	list, diags := types.ListValue(types.StringType, vals)
+	if diags.HasError() {
+		t.Fatalf("mustListValue: %v", diags)
+	}
+	return list
+}
+
+func TestResolveIgnoreJSONPath_valid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path           string
+		wantStep       string
+		wantField      string
+		wantInJSONPath string
+	}{
+		{
+			path:           "definition.steps['Create Ticket'].attributes.param_oauth.refID",
+			wantStep:       "Create Ticket",
+			wantField:      "attributes",
+			wantInJSONPath: "param_oauth.refID",
+		},
+		{
+			path:           "definition.steps['step1'].config.someKey",
+			wantStep:       "step1",
+			wantField:      "config",
+			wantInJSONPath: "someKey",
+		},
+		{
+			path:           "definition.steps[\"my step\"].catch.error.code",
+			wantStep:       "my step",
+			wantField:      "catch",
+			wantInJSONPath: "error.code",
+		},
+		{
+			path:           "definition.steps['s'].attributes.items[*].refID",
+			wantStep:       "s",
+			wantField:      "attributes",
+			wantInJSONPath: "items[*].refID",
+		},
+		{
+			path:           "definition.steps['s'].attributes.nested.deep.key",
+			wantStep:       "s",
+			wantField:      "attributes",
+			wantInJSONPath: "nested.deep.key",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			stepName, field, inJSONPath, err := resolveIgnoreJSONPath(tc.path)
+			if err != nil {
+				t.Fatalf("resolveIgnoreJSONPath(%q) unexpected error: %v", tc.path, err)
+			}
+			if stepName != tc.wantStep {
+				t.Errorf("stepName = %q, want %q", stepName, tc.wantStep)
+			}
+			if field != tc.wantField {
+				t.Errorf("field = %q, want %q", field, tc.wantField)
+			}
+			if inJSONPath != tc.wantInJSONPath {
+				t.Errorf("inJSONPath = %q, want %q", inJSONPath, tc.wantInJSONPath)
+			}
+		})
+	}
+}
+
+func TestResolveIgnoreJSONPath_invalid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+	}{
+		{path: "steps['step'].attributes.key"},           // missing "definition." prefix
+		{path: "definition.steps.step.attributes.key"},   // step not bracket-quoted
+		{path: "definition.steps[''].attributes.key"},    // empty step name
+		{path: "definition.steps['step'].attributes"},    // no in-JSON path (missing dot + path)
+		{path: "definition.steps['step'].name.key"},      // "name" is not a JSON step field
+		{path: "definition.steps['step'].attributes."},   // trailing dot in in-JSON path
+		{path: "definition.steps['step'].owner.somekey"}, // "owner" is not a JSON step field
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			_, _, _, err := resolveIgnoreJSONPath(tc.path)
+			if err == nil {
+				t.Errorf("resolveIgnoreJSONPath(%q) expected error, got nil", tc.path)
+			}
+		})
+	}
+}
+
+// TestApplyIgnoreJSONChanges_DriftSuppression_Create verifies that after a Create,
+// the server-minted refID is replaced by the practitioner's placeholder value.
+func TestApplyIgnoreJSONChanges_DriftSuppression_Create(t *testing.T) {
+	t.Parallel()
+
+	// Plan: param_oauth.refID = "placeholder" (practitioner's input)
+	planStep := mustStepObject(t, map[string]attr.Value{
+		"type":       types.StringValue("action"),
+		"action_id":  types.StringValue("sp:http"),
+		"attributes": jsontypes.NewNormalizedValue(`{"url":"https://example.com","param_oauth":{"refID":"placeholder"}}`),
+	})
+	planModel := workflowModel{
+		Name:           types.StringValue("test"),
+		Definition:     mustDefinitionObject(t, "Create Ticket", mustStepsMap(t, map[string]types.Object{"Create Ticket": planStep})),
+		Owner:          types.ObjectNull(objectRefAttrTypes()),
+		Trigger:        jsontypes.NewNormalizedNull(),
+		Created:        types.StringNull(),
+		Modified:       types.StringNull(),
+		Creator:        types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:     types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount: types.Int32Value(0),
+		FailureCount:   types.Int32Value(0),
+		IgnoreJSONChanges: mustListValue(t, []string{
+			"definition.steps['Create Ticket'].attributes.param_oauth.refID",
+		}),
+	}
+
+	// Simulate API response: server minted refID to a different value
+	apiStep := mustStepObject(t, map[string]attr.Value{
+		"type":       types.StringValue("action"),
+		"action_id":  types.StringValue("sp:http"),
+		"attributes": jsontypes.NewNormalizedValue(`{"url":"https://example.com","param_oauth":{"refID":"server-minted-id"}}`),
+	})
+	newModel := workflowModel{
+		Name:              types.StringValue("test"),
+		Definition:        mustDefinitionObject(t, "Create Ticket", mustStepsMap(t, map[string]types.Object{"Create Ticket": apiStep})),
+		Owner:             types.ObjectNull(objectRefAttrTypes()),
+		Trigger:           jsontypes.NewNormalizedNull(),
+		Created:           types.StringNull(),
+		Modified:          types.StringNull(),
+		Creator:           types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:        types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount:    types.Int32Value(0),
+		FailureCount:      types.Int32Value(0),
+		IgnoreJSONChanges: planModel.IgnoreJSONChanges,
+	}
+
+	// Apply (Create flow: source = plan)
+	diags := applyIgnoreJSONChanges(&newModel, &planModel, planModel.IgnoreJSONChanges)
+	if diags.HasError() {
+		t.Fatalf("applyIgnoreJSONChanges: %v", diags)
+	}
+
+	// Verify refID kept the practitioner's value, not the server's
+	refID := mustExtractRefID(t, newModel, "Create Ticket")
+	if refID != "placeholder" {
+		t.Errorf("refID = %q, want %q (server drift not suppressed)", refID, "placeholder")
+	}
+}
+
+// TestApplyIgnoreJSONChanges_DriftSuppression_Read verifies that on subsequent reads
+// the prior-state value is preserved at ignored paths.
+func TestApplyIgnoreJSONChanges_DriftSuppression_Read(t *testing.T) {
+	t.Parallel()
+
+	// Prior state: param_oauth.refID = "placeholder"
+	priorStep := mustStepObject(t, map[string]attr.Value{
+		"type":       types.StringValue("action"),
+		"action_id":  types.StringValue("sp:http"),
+		"attributes": jsontypes.NewNormalizedValue(`{"url":"https://example.com","param_oauth":{"refID":"placeholder"}}`),
+	})
+	priorState := workflowModel{
+		Name:           types.StringValue("test"),
+		Definition:     mustDefinitionObject(t, "Create Ticket", mustStepsMap(t, map[string]types.Object{"Create Ticket": priorStep})),
+		Owner:          types.ObjectNull(objectRefAttrTypes()),
+		Trigger:        jsontypes.NewNormalizedNull(),
+		Created:        types.StringNull(),
+		Modified:       types.StringNull(),
+		Creator:        types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:     types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount: types.Int32Value(0),
+		FailureCount:   types.Int32Value(0),
+		IgnoreJSONChanges: mustListValue(t, []string{
+			"definition.steps['Create Ticket'].attributes.param_oauth.refID",
+		}),
+	}
+
+	// API returns the server-minted value again
+	apiStep := mustStepObject(t, map[string]attr.Value{
+		"type":       types.StringValue("action"),
+		"action_id":  types.StringValue("sp:http"),
+		"attributes": jsontypes.NewNormalizedValue(`{"url":"https://example.com","param_oauth":{"refID":"server-minted-id"}}`),
+	})
+	newModel := workflowModel{
+		Name:              types.StringValue("test"),
+		Definition:        mustDefinitionObject(t, "Create Ticket", mustStepsMap(t, map[string]types.Object{"Create Ticket": apiStep})),
+		Owner:             types.ObjectNull(objectRefAttrTypes()),
+		Trigger:           jsontypes.NewNormalizedNull(),
+		Created:           types.StringNull(),
+		Modified:          types.StringNull(),
+		Creator:           types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:        types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount:    types.Int32Value(0),
+		FailureCount:      types.Int32Value(0),
+		IgnoreJSONChanges: priorState.IgnoreJSONChanges,
+	}
+
+	// Apply (Read flow: source = prior state)
+	diags := applyIgnoreJSONChanges(&newModel, &priorState, priorState.IgnoreJSONChanges)
+	if diags.HasError() {
+		t.Fatalf("applyIgnoreJSONChanges: %v", diags)
+	}
+
+	refID := mustExtractRefID(t, newModel, "Create Ticket")
+	if refID != "placeholder" {
+		t.Errorf("refID = %q, want %q (server drift not suppressed on read)", refID, "placeholder")
+	}
+}
+
+// TestApplyIgnoreJSONChanges_NoIgnorePaths verifies that a nil/null ignore list is a no-op.
+func TestApplyIgnoreJSONChanges_NoIgnorePaths(t *testing.T) {
+	t.Parallel()
+
+	apiStep := mustStepObject(t, map[string]attr.Value{
+		"type":       types.StringValue("action"),
+		"action_id":  types.StringValue("sp:http"),
+		"attributes": jsontypes.NewNormalizedValue(`{"url":"https://example.com","param_oauth":{"refID":"server-minted-id"}}`),
+	})
+	model := workflowModel{
+		Name:              types.StringValue("test"),
+		Definition:        mustDefinitionObject(t, "s", mustStepsMap(t, map[string]types.Object{"s": apiStep})),
+		Owner:             types.ObjectNull(objectRefAttrTypes()),
+		Trigger:           jsontypes.NewNormalizedNull(),
+		Created:           types.StringNull(),
+		Modified:          types.StringNull(),
+		Creator:           types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:        types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount:    types.Int32Value(0),
+		FailureCount:      types.Int32Value(0),
+		IgnoreJSONChanges: types.ListNull(types.StringType),
+	}
+	source := model
+
+	diags := applyIgnoreJSONChanges(&model, &source, types.ListNull(types.StringType))
+	if diags.HasError() {
+		t.Fatalf("applyIgnoreJSONChanges: %v", diags)
+	}
+	// No change expected — server-minted value stays
+	refID := mustExtractRefID(t, model, "s")
+	if refID != "server-minted-id" {
+		t.Errorf("refID = %q, want %q", refID, "server-minted-id")
+	}
+}
+
+// TestApplyIgnoreJSONChanges_MissingSourceStep verifies that when the step is absent
+// from the source (e.g. a brand-new step on create), the path is silently skipped.
+func TestApplyIgnoreJSONChanges_MissingSourceStep(t *testing.T) {
+	t.Parallel()
+
+	// Source has no "New Step"
+	sourceModel := workflowModel{
+		Name:              types.StringValue("test"),
+		Definition:        mustDefinitionObject(t, "Old Step", mustStepsMap(t, map[string]types.Object{})),
+		Owner:             types.ObjectNull(objectRefAttrTypes()),
+		Trigger:           jsontypes.NewNormalizedNull(),
+		Created:           types.StringNull(),
+		Modified:          types.StringNull(),
+		Creator:           types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:        types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount:    types.Int32Value(0),
+		FailureCount:      types.Int32Value(0),
+		IgnoreJSONChanges: types.ListNull(types.StringType),
+	}
+
+	apiStep := mustStepObject(t, map[string]attr.Value{
+		"type":       types.StringValue("action"),
+		"attributes": jsontypes.NewNormalizedValue(`{"param_oauth":{"refID":"server-minted-id"}}`),
+	})
+	newModel := workflowModel{
+		Name:              types.StringValue("test"),
+		Definition:        mustDefinitionObject(t, "New Step", mustStepsMap(t, map[string]types.Object{"New Step": apiStep})),
+		Owner:             types.ObjectNull(objectRefAttrTypes()),
+		Trigger:           jsontypes.NewNormalizedNull(),
+		Created:           types.StringNull(),
+		Modified:          types.StringNull(),
+		Creator:           types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:        types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount:    types.Int32Value(0),
+		FailureCount:      types.Int32Value(0),
+		IgnoreJSONChanges: types.ListNull(types.StringType),
+	}
+
+	paths := mustListValue(t, []string{"definition.steps['New Step'].attributes.param_oauth.refID"})
+	diags := applyIgnoreJSONChanges(&newModel, &sourceModel, paths)
+	if diags.HasError() {
+		t.Fatalf("applyIgnoreJSONChanges: %v", diags)
+	}
+	// Server-minted value should remain unchanged (step absent from source → skip)
+	refID := mustExtractRefID(t, newModel, "New Step")
+	if refID != "server-minted-id" {
+		t.Errorf("refID = %q, want %q (should be unchanged when step absent from source)", refID, "server-minted-id")
+	}
+}
+
+// mustExtractRefID is a test helper that navigates newModel.definition.steps[stepName].attributes
+// and returns param_oauth.refID as a string. Fails the test if any step is missing.
+func mustExtractRefID(t *testing.T, m workflowModel, stepName string) string {
+	t.Helper()
+	defAttrs := m.Definition.Attributes()
+	stepsMap, ok := defAttrs["steps"].(types.Map)
+	if !ok {
+		t.Fatalf("mustExtractRefID: steps is not types.Map")
+	}
+	stepVal, ok := stepsMap.Elements()[stepName].(types.Object)
+	if !ok {
+		t.Fatalf("mustExtractRefID: step %q missing", stepName)
+	}
+	attrVal, ok := stepVal.Attributes()["attributes"].(jsontypes.Normalized)
+	if !ok || attrVal.IsNull() {
+		t.Fatalf("mustExtractRefID: attributes is null or wrong type")
+	}
+	var attrMap map[string]any
+	if err := json.Unmarshal([]byte(attrVal.ValueString()), &attrMap); err != nil {
+		t.Fatalf("mustExtractRefID: unmarshal: %v", err)
+	}
+	paramOAuth, ok := attrMap["param_oauth"].(map[string]any)
+	if !ok {
+		t.Fatalf("mustExtractRefID: param_oauth not a map")
+	}
+	refID, ok := paramOAuth["refID"].(string)
+	if !ok {
+		t.Fatalf("mustExtractRefID: refID not a string")
+	}
+	return refID
+}

--- a/internal/services/workflow/workflow_model.go
+++ b/internal/services/workflow/workflow_model.go
@@ -47,19 +47,20 @@ var promotedStepKeys = map[string]bool{
 
 // workflowModel represents the Terraform model for a SailPoint Workflow.
 type workflowModel struct {
-	ID             types.String         `tfsdk:"id"`
-	Name           types.String         `tfsdk:"name"`
-	Owner          types.Object         `tfsdk:"owner"`
-	Description    types.String         `tfsdk:"description"`
-	Definition     types.Object         `tfsdk:"definition"`
-	Trigger        jsontypes.Normalized `tfsdk:"trigger"`
-	Enabled        types.Bool           `tfsdk:"enabled"`
-	Created        types.String         `tfsdk:"created"`
-	Modified       types.String         `tfsdk:"modified"`
-	Creator        types.Object         `tfsdk:"creator"`
-	ModifiedBy     types.Object         `tfsdk:"modified_by"`
-	ExecutionCount types.Int32          `tfsdk:"execution_count"`
-	FailureCount   types.Int32          `tfsdk:"failure_count"`
+	ID                types.String         `tfsdk:"id"`
+	Name              types.String         `tfsdk:"name"`
+	Owner             types.Object         `tfsdk:"owner"`
+	Description       types.String         `tfsdk:"description"`
+	Definition        types.Object         `tfsdk:"definition"`
+	Trigger           jsontypes.Normalized `tfsdk:"trigger"`
+	Enabled           types.Bool           `tfsdk:"enabled"`
+	Created           types.String         `tfsdk:"created"`
+	Modified          types.String         `tfsdk:"modified"`
+	Creator           types.Object         `tfsdk:"creator"`
+	ModifiedBy        types.Object         `tfsdk:"modified_by"`
+	ExecutionCount    types.Int32          `tfsdk:"execution_count"`
+	FailureCount      types.Int32          `tfsdk:"failure_count"`
+	IgnoreJSONChanges types.List           `tfsdk:"ignore_json_changes"`
 }
 
 // objectRefAttrTypes returns the attribute types for ObjectRef-like nested objects.

--- a/internal/services/workflow/workflow_resource.go
+++ b/internal/services/workflow/workflow_resource.go
@@ -20,14 +20,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
-	_ resource.Resource                 = &workflowResource{}
-	_ resource.ResourceWithConfigure    = &workflowResource{}
-	_ resource.ResourceWithImportState  = &workflowResource{}
-	_ resource.ResourceWithUpgradeState = &workflowResource{}
+	_ resource.Resource                   = &workflowResource{}
+	_ resource.ResourceWithConfigure      = &workflowResource{}
+	_ resource.ResourceWithImportState    = &workflowResource{}
+	_ resource.ResourceWithUpgradeState   = &workflowResource{}
+	_ resource.ResourceWithValidateConfig = &workflowResource{}
 )
 
 type workflowResource struct {
@@ -51,6 +53,35 @@ func (r *workflowResource) Configure(ctx context.Context, req resource.Configure
 		return
 	}
 	r.client = c
+}
+
+// ValidateConfig implements resource.ResourceWithValidateConfig.
+func (r *workflowResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config workflowModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.IgnoreJSONChanges.IsNull() || config.IgnoreJSONChanges.IsUnknown() {
+		return
+	}
+
+	var paths []string
+	resp.Diagnostics.Append(config.IgnoreJSONChanges.ElementsAs(ctx, &paths, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for _, p := range paths {
+		if _, _, _, err := resolveIgnoreJSONPath(p); err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("ignore_json_changes"),
+				"Invalid ignore_json_changes path",
+				fmt.Sprintf("Path %q is not valid: %s", p, err.Error()),
+			)
+		}
+	}
 }
 
 // Schema implements resource.Resource.
@@ -252,6 +283,11 @@ func (r *workflowResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					},
 				},
 			},
+			"ignore_json_changes": schema.ListAttribute{
+				MarkdownDescription: "Paths inside JSON step fields whose server-minted drift the practitioner chooses to ignore (analogous to `ignore_changes`, but reaching inside JSON-string attributes). Each entry has the form `definition.steps['<step name>'].<field>.<json-path>` where `<field>` is one of `attributes`, `config`, or `catch` and `<json-path>` is a dotted path inside that JSON object (e.g. `param_oauth.refID`).",
+				Optional:            true,
+				ElementType:         types.StringType,
+			},
 		},
 	}
 }
@@ -311,6 +347,14 @@ func (r *workflowResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	// Copy ignore_json_changes from plan (not an API field) and re-inject plan
+	// values at each ignored path so server-minted values never enter state.
+	state.IgnoreJSONChanges = plan.IgnoreJSONChanges
+	resp.Diagnostics.Append(applyIgnoreJSONChanges(&state, &plan, plan.IgnoreJSONChanges)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Set the state
 	tflog.Debug(ctx, "Setting state for workflow resource", map[string]any{
 		"id":   state.ID.ValueString(),
@@ -328,33 +372,33 @@ func (r *workflowResource) Create(ctx context.Context, req resource.CreateReques
 
 // Read implements resource.Resource.
 func (r *workflowResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var state workflowModel
+	var priorState workflowModel
 	tflog.Debug(ctx, "Getting state for workflow resource read")
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Read the workflow from SailPoint
 	tflog.Debug(ctx, "Fetching workflow from SailPoint", map[string]any{
-		"id": state.ID.ValueString(),
+		"id": priorState.ID.ValueString(),
 	})
-	workflowResponse, err := r.client.GetWorkflow(ctx, state.ID.ValueString())
+	workflowResponse, err := r.client.GetWorkflow(ctx, priorState.ID.ValueString())
 	if err != nil {
 		// If resource was deleted outside of Terraform, remove it from state
 		if errors.Is(err, client.ErrNotFound) {
 			tflog.Info(ctx, "SailPoint Workflow not found, removing from state", map[string]any{
-				"id": state.ID.ValueString(),
+				"id": priorState.ID.ValueString(),
 			})
 			resp.State.RemoveResource(ctx)
 			return
 		}
 		resp.Diagnostics.AddError(
 			"Error Reading SailPoint Workflow",
-			fmt.Sprintf("Could not read SailPoint Workflow %q: %s", state.ID.ValueString(), err.Error()),
+			fmt.Sprintf("Could not read SailPoint Workflow %q: %s", priorState.ID.ValueString(), err.Error()),
 		)
 		tflog.Error(ctx, "Failed to read SailPoint Workflow", map[string]any{
-			"id":    state.ID.ValueString(),
+			"id":    priorState.ID.ValueString(),
 			"error": err.Error(),
 		})
 		return
@@ -370,9 +414,18 @@ func (r *workflowResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	// Map the response to the resource model
 	tflog.Debug(ctx, "Mapping SailPoint Workflow API response to resource model", map[string]any{
-		"id": state.ID.ValueString(),
+		"id": priorState.ID.ValueString(),
 	})
+	var state workflowModel
 	resp.Diagnostics.Append(state.FromAPI(ctx, *workflowResponse)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Restore ignore_json_changes from prior state (not an API field) and
+	// re-inject prior values at each ignored path to suppress server drift.
+	state.IgnoreJSONChanges = priorState.IgnoreJSONChanges
+	resp.Diagnostics.Append(applyIgnoreJSONChanges(&state, &priorState, priorState.IgnoreJSONChanges)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -457,6 +510,14 @@ func (r *workflowResource) Update(ctx context.Context, req resource.UpdateReques
 		"id": state.ID.ValueString(),
 	})
 	resp.Diagnostics.Append(newState.FromAPI(ctx, *workflowAPIResponse)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Copy ignore_json_changes from plan (not an API field) and re-inject
+	// prior-state values at each ignored path to suppress server drift.
+	newState.IgnoreJSONChanges = plan.IgnoreJSONChanges
+	resp.Diagnostics.Append(applyIgnoreJSONChanges(&newState, &state, plan.IgnoreJSONChanges)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/services/workflow/workflow_state_upgrader.go
+++ b/internal/services/workflow/workflow_state_upgrader.go
@@ -202,18 +202,19 @@ func upgradeWorkflowStateV0ToV2(ctx context.Context, req resource.UpgradeStateRe
 	}
 
 	upgraded := workflowModel{
-		ID:             prior.ID,
-		Name:           prior.Name,
-		Owner:          prior.Owner,
-		Description:    prior.Description,
-		Trigger:        prior.Trigger,
-		Enabled:        prior.Enabled,
-		Created:        prior.Created,
-		Modified:       prior.Modified,
-		Creator:        prior.Creator,
-		ModifiedBy:     prior.ModifiedBy,
-		ExecutionCount: prior.ExecutionCount,
-		FailureCount:   prior.FailureCount,
+		ID:                prior.ID,
+		Name:              prior.Name,
+		Owner:             prior.Owner,
+		Description:       prior.Description,
+		Trigger:           prior.Trigger,
+		Enabled:           prior.Enabled,
+		Created:           prior.Created,
+		Modified:          prior.Modified,
+		Creator:           prior.Creator,
+		ModifiedBy:        prior.ModifiedBy,
+		ExecutionCount:    prior.ExecutionCount,
+		FailureCount:      prior.FailureCount,
+		IgnoreJSONChanges: types.ListNull(types.StringType),
 	}
 
 	defObj, diags := upgradeDefinitionToV2(prior.Definition)
@@ -242,18 +243,19 @@ func upgradeWorkflowStateV1ToV2(ctx context.Context, req resource.UpgradeStateRe
 	}
 
 	upgraded := workflowModel{
-		ID:             prior.ID,
-		Name:           prior.Name,
-		Owner:          prior.Owner,
-		Description:    prior.Description,
-		Trigger:        prior.Trigger,
-		Enabled:        prior.Enabled,
-		Created:        prior.Created,
-		Modified:       prior.Modified,
-		Creator:        prior.Creator,
-		ModifiedBy:     prior.ModifiedBy,
-		ExecutionCount: prior.ExecutionCount,
-		FailureCount:   prior.FailureCount,
+		ID:                prior.ID,
+		Name:              prior.Name,
+		Owner:             prior.Owner,
+		Description:       prior.Description,
+		Trigger:           prior.Trigger,
+		Enabled:           prior.Enabled,
+		Created:           prior.Created,
+		Modified:          prior.Modified,
+		Creator:           prior.Creator,
+		ModifiedBy:        prior.ModifiedBy,
+		ExecutionCount:    prior.ExecutionCount,
+		FailureCount:      prior.FailureCount,
+		IgnoreJSONChanges: types.ListNull(types.StringType),
 	}
 
 	defObj, diags := upgradeDefinitionToV2(prior.Definition)


### PR DESCRIPTION
First consumer of the provider-wide `ignore_json_changes` feature (foundation merged in #145). Restores `sp:http` `refID` drift suppression that the steps remodel (#141) removed — now practitioner-driven instead of hardcoded.

- New `ignore_json_changes` (Optional list of String) on the **resource** (kept off the data source via a separate `workflowDSModel`).
- Path form `definition.steps['<step>'].{attributes|config|catch}.<json-path>`. `resolveIgnoreJSONPath` parses it; `ValidateConfig` rejects malformed paths or ones not targeting a JSON step field.
- `applyIgnoreJSONChanges` re-injects the controlling value after `FromAPI` — **Create**: from config; **Read/Update**: from prior state — via `jsonpath.PreservePathsInJSON`, so server-minted values never enter state (no drift, no create inconsistency).
- State upgraders initialise the attribute to null.
- Tests: resolver valid/invalid (incl. `[*]` wildcard, double-quoted keys, `catch`), Create + Read drift suppression, no-paths, missing-source-step. Example added to `http_request.tf`.

Refs #142 — transform / form_definition / identity_profile / source consumers are separate follow-ups.
