### PR TITLE
feat(workflow): make enabled *bool + ForceDisabledOnCreate plan modifier

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -63,7 +63,7 @@ resource "sailpoint_workflow" "send_email" {
 
 - `definition` (Attributes) The workflow definition containing the steps to execute. If not specified, the workflow will have no definition. (see [below for nested schema](#nestedatt--definition))
 - `description` (String) The description of the workflow.
-- `enabled` (Boolean) Whether the workflow is enabled. Workflows cannot be created in an enabled state. Defaults to `false`.
+- `enabled` (Boolean) Whether the workflow is enabled. Defaults to `false`. Because the SailPoint API cannot create an enabled workflow, declaring `enabled = true` at create time will produce `enabled = false` in state; the next `terraform apply` (an update) will enable the workflow (converge-over-two-applies).
 - `ignore_json_changes` (List of String) Paths inside JSON step fields whose server-minted drift the practitioner chooses to ignore (analogous to `ignore_changes`, but reaching inside JSON-string attributes). Each entry has the form `definition.steps['<step name>'].<field>.<json-path>` where `<field>` is one of `attributes`, `config`, or `catch` and `<json-path>` is a dotted path inside that JSON object (e.g. `param_oauth.refID`).
 
 ### Read-Only

--- a/internal/client/workflows.go
+++ b/internal/client/workflows.go
@@ -28,7 +28,7 @@ type WorkflowAPI struct {
 	Description    string                 `json:"description,omitempty"`
 	Definition     *WorkflowDefinitionAPI `json:"definition,omitempty"`
 	Trigger        *WorkflowTriggerAPI    `json:"trigger,omitempty"`
-	Enabled        bool                   `json:"enabled,omitempty"`
+	Enabled        *bool                  `json:"enabled,omitempty"`
 	Created        string                 `json:"created,omitempty"`
 	Modified       string                 `json:"modified,omitempty"`
 	Creator        *ObjectRefAPI          `json:"creator,omitempty"`

--- a/internal/common/planmodifiers/force_disabled_on_create.go
+++ b/internal/common/planmodifiers/force_disabled_on_create.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package planmodifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ForceDisabledOnCreate returns a plan modifier that sets the planned value of a
+// bool attribute to false on resource creation (when there is no prior state).
+// On updates the planned value is left unchanged.
+//
+// Use this for the workflow enabled attribute: the SailPoint API cannot create a
+// workflow in the enabled state. Declaring enabled = true at create time will
+// produce enabled = false in state; the next apply (an update) will enable the
+// workflow ("converge over two applies").
+func ForceDisabledOnCreate() planmodifier.Bool {
+	return forceDisabledOnCreateModifier{}
+}
+
+type forceDisabledOnCreateModifier struct{}
+
+func (m forceDisabledOnCreateModifier) Description(_ context.Context) string {
+	return "Forces the planned value to false on create; on update the declared value is used as-is."
+}
+
+func (m forceDisabledOnCreateModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m forceDisabledOnCreateModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// On create there is no prior state, so StateValue is null.
+	// Force the planned value to false: the API cannot create an enabled workflow.
+	if req.StateValue.IsNull() {
+		resp.PlanValue = types.BoolValue(false)
+	}
+}

--- a/internal/common/planmodifiers/force_disabled_on_create_test.go
+++ b/internal/common/planmodifiers/force_disabled_on_create_test.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package planmodifiers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestForceDisabledOnCreate_ForcesToFalseOnCreate(t *testing.T) {
+	t.Parallel()
+
+	modifier := ForceDisabledOnCreate()
+	req := planmodifier.BoolRequest{
+		StateValue: types.BoolNull(), // null state value = create (no prior state)
+		PlanValue:  types.BoolValue(true),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+	modifier.PlanModifyBool(context.Background(), req, resp)
+
+	if resp.PlanValue.ValueBool() {
+		t.Error("expected PlanValue to be forced to false on create, got true")
+	}
+}
+
+func TestForceDisabledOnCreate_PassesThroughOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	modifier := ForceDisabledOnCreate()
+	req := planmodifier.BoolRequest{
+		StateValue: types.BoolValue(false), // non-null state value = update
+		PlanValue:  types.BoolValue(true),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+	modifier.PlanModifyBool(context.Background(), req, resp)
+
+	if !resp.PlanValue.ValueBool() {
+		t.Error("expected PlanValue to remain true on update, got false")
+	}
+}
+
+func TestForceDisabledOnCreate_AlreadyFalseOnCreate(t *testing.T) {
+	t.Parallel()
+
+	modifier := ForceDisabledOnCreate()
+	req := planmodifier.BoolRequest{
+		StateValue: types.BoolNull(),
+		PlanValue:  types.BoolValue(false),
+	}
+	resp := &planmodifier.BoolResponse{PlanValue: req.PlanValue}
+	modifier.PlanModifyBool(context.Background(), req, resp)
+
+	if resp.PlanValue.ValueBool() {
+		t.Error("expected PlanValue to remain false on create")
+	}
+}

--- a/internal/services/workflow/workflow_model.go
+++ b/internal/services/workflow/workflow_model.go
@@ -295,7 +295,8 @@ func (m *workflowModel) ToAPI(ctx context.Context) (client.WorkflowAPI, diag.Dia
 	}
 
 	if !m.Enabled.IsNull() && !m.Enabled.IsUnknown() {
-		api.Enabled = m.Enabled.ValueBool()
+		v := m.Enabled.ValueBool()
+		api.Enabled = &v
 	}
 
 	return api, diagnostics
@@ -343,7 +344,7 @@ func (m *workflowModel) FromAPI(ctx context.Context, api client.WorkflowAPI) dia
 		m.Trigger = jsontypes.NewNormalizedNull()
 	}
 
-	m.Enabled = types.BoolValue(api.Enabled)
+	m.Enabled = types.BoolValue(api.Enabled != nil && *api.Enabled)
 	m.Created = common.StringOrNullIfEmpty(api.Created)
 	m.Modified = common.StringOrNullIfEmpty(api.Modified)
 

--- a/internal/services/workflow/workflow_model_test.go
+++ b/internal/services/workflow/workflow_model_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func mustBoolPtr(b bool) *bool { return &b }
+
 // mustStepObject builds a typed step types.Object for tests.
 func mustStepObject(t *testing.T, attrs map[string]attr.Value) types.Object {
 	t.Helper()
@@ -220,5 +222,111 @@ func TestWorkflowModel_ToAPI_FromAPI_RoundTrip_ChoiceStep(t *testing.T) {
 	}
 	if v, ok := rtAttrs["action_id"].(types.String); ok && !v.IsNull() {
 		t.Errorf("FromAPI: action_id should be null for choice step, got %v", v.ValueString())
+	}
+}
+
+// TestWorkflowModel_Enabled_FalseRoundTrip verifies that an explicit enabled=false
+// survives ToAPI (as a non-nil *bool) and FromAPI without becoming null or true.
+func TestWorkflowModel_Enabled_FalseRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	m := workflowModel{
+		Name:           types.StringValue("wf"),
+		Enabled:        types.BoolValue(false),
+		Owner:          types.ObjectNull(objectRefAttrTypes()),
+		Trigger:        jsontypes.NewNormalizedNull(),
+		Created:        types.StringNull(),
+		Modified:       types.StringNull(),
+		Creator:        types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:     types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount: types.Int32Value(0),
+		FailureCount:   types.Int32Value(0),
+	}
+
+	api, diags := m.ToAPI(ctx)
+	if diags.HasError() {
+		t.Fatalf("ToAPI: %v", diags)
+	}
+	if api.Enabled == nil {
+		t.Fatal("ToAPI: Enabled is nil; want non-nil *bool so false is transmitted on the wire")
+	}
+	if *api.Enabled {
+		t.Error("ToAPI: Enabled is true; want false")
+	}
+
+	var roundTripped workflowModel
+	if diags := roundTripped.FromAPI(ctx, api); diags.HasError() {
+		t.Fatalf("FromAPI: %v", diags)
+	}
+	if roundTripped.Enabled.IsNull() {
+		t.Error("FromAPI: Enabled is null; want false")
+	}
+	if roundTripped.Enabled.ValueBool() {
+		t.Error("FromAPI: Enabled is true after round-trip; want false")
+	}
+}
+
+// TestWorkflowModel_Enabled_NilAPIIsFalse verifies that a nil Enabled pointer in the
+// API response (field absent or null) maps to false in the Terraform model.
+func TestWorkflowModel_Enabled_NilAPIIsFalse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	apiResponse := client.WorkflowAPI{
+		ID:      "wf-id",
+		Name:    "wf",
+		Enabled: nil, // absent in API response
+	}
+	var m workflowModel
+	if diags := m.FromAPI(ctx, apiResponse); diags.HasError() {
+		t.Fatalf("FromAPI: %v", diags)
+	}
+	if m.Enabled.IsNull() {
+		t.Error("FromAPI: Enabled is null; nil API value should yield false, not null")
+	}
+	if m.Enabled.ValueBool() {
+		t.Error("FromAPI: Enabled is true; nil API value should yield false")
+	}
+}
+
+// TestWorkflowModel_Enabled_TrueRoundTrip verifies that enabled=true transmits
+// correctly through ToAPI and back via FromAPI.
+func TestWorkflowModel_Enabled_TrueRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	m := workflowModel{
+		Name:           types.StringValue("wf"),
+		Enabled:        types.BoolValue(true),
+		Owner:          types.ObjectNull(objectRefAttrTypes()),
+		Trigger:        jsontypes.NewNormalizedNull(),
+		Created:        types.StringNull(),
+		Modified:       types.StringNull(),
+		Creator:        types.ObjectNull(objectRefAttrTypes()),
+		ModifiedBy:     types.ObjectNull(objectRefAttrTypes()),
+		ExecutionCount: types.Int32Value(0),
+		FailureCount:   types.Int32Value(0),
+	}
+
+	api, diags := m.ToAPI(ctx)
+	if diags.HasError() {
+		t.Fatalf("ToAPI: %v", diags)
+	}
+	if api.Enabled == nil {
+		t.Fatal("ToAPI: Enabled is nil; want non-nil *bool")
+	}
+	if !*api.Enabled {
+		t.Error("ToAPI: Enabled is false; want true")
+	}
+
+	// Simulate API echoing true back.
+	apiResponse := client.WorkflowAPI{ID: "wf-id", Name: "wf", Enabled: mustBoolPtr(true)}
+	var roundTripped workflowModel
+	if diags := roundTripped.FromAPI(ctx, apiResponse); diags.HasError() {
+		t.Fatalf("FromAPI: %v", diags)
+	}
+	if !roundTripped.Enabled.ValueBool() {
+		t.Error("FromAPI: Enabled is false after round-trip; want true")
 	}
 }

--- a/internal/services/workflow/workflow_resource.go
+++ b/internal/services/workflow/workflow_resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -110,10 +111,16 @@ func (r *workflowResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:            true,
 			},
 			"enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether the workflow is enabled. Workflows cannot be created in an enabled state. Defaults to `false`.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Whether the workflow is enabled. Defaults to `false`. " +
+					"Because the SailPoint API cannot create an enabled workflow, declaring `enabled = true` at " +
+					"create time will produce `enabled = false` in state; the next `terraform apply` (an update) " +
+					"will enable the workflow (converge-over-two-applies).",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					planmodifiers.ForceDisabledOnCreate(),
+				},
 			},
 			"trigger": schema.StringAttribute{
 				MarkdownDescription: "The trigger configuration as JSON. This is a computed field - use `sailpoint_workflow_trigger` resource to manage triggers.",
@@ -559,7 +566,8 @@ func (r *workflowResource) Delete(ctx context.Context, req resource.DeleteReques
 			return
 		}
 
-		apiWorkflow.Enabled = false
+		falseVal := false
+		apiWorkflow.Enabled = &falseVal
 
 		// Update to disable the workflow
 		_, err := r.client.UpdateWorkflow(ctx, state.ID.ValueString(), &apiWorkflow)

--- a/internal/services/workflow_trigger/workflow_trigger_resource.go
+++ b/internal/services/workflow_trigger/workflow_trigger_resource.go
@@ -237,14 +237,15 @@ func (r *workflowTriggerResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	wasEnabled := currentWorkflow.Enabled
+	wasEnabled := currentWorkflow.Enabled != nil && *currentWorkflow.Enabled
 	if wasEnabled {
 		// PATCH is blocked on enabled workflows, so we must use PUT to disable first.
 		tflog.Info(ctx, "Workflow is enabled, disabling before trigger update", map[string]any{
 			"workflow_id": workflowID,
 		})
 		disabledWorkflow := *currentWorkflow
-		disabledWorkflow.Enabled = false
+		falseVal := false
+		disabledWorkflow.Enabled = &falseVal
 		if _, disableErr := r.client.UpdateWorkflow(ctx, workflowID, &disabledWorkflow); disableErr != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating Workflow Trigger",


### PR DESCRIPTION
Last of the workflow v3 set (#143).

Practitioner fully controls `enabled`; the provider never silently flips it; and since SailPoint can't create an enabled workflow, a declared `enabled = true` converges on the *next* apply.

- Client `WorkflowAPI.Enabled` → `*bool` so an explicit `false` is transmitted (pointer + `omitempty` drops only nil). `ToAPI` sets `&v`; `FromAPI` maps nil → false.
- New reusable `forceDisabledOnCreate` bool plan modifier (`internal/common/planmodifiers`): forces planned `enabled = false` on **create**, no-op on **update** — prevents *"inconsistent result after apply"* when `enabled = true` is declared at create.
- `enabled` stays **Optional + Computed + Default(false)**.
- Update mirrors the declared value (never side-effect flips); Delete keeps disable-before-delete. The `workflow_trigger` resource is updated for the `*bool` change.
- Tests: plan modifier (create forces false / update passes through) + model round-trip.

Closes #140.
