### PR TITLE
fix(workflow_trigger): disable→patch→re-enable cycle for enabled workflows

### DIFF
--- a/internal/services/workflow_trigger/workflow_trigger_disable.go
+++ b/internal/services/workflow_trigger/workflow_trigger_disable.go
@@ -1,0 +1,79 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow_trigger
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// workflowStateManager abstracts the client calls needed by withWorkflowDisabled,
+// allowing the helper to be tested without a live HTTP server.
+type workflowStateManager interface {
+	GetWorkflow(ctx context.Context, id string) (*client.WorkflowAPI, error)
+	UpdateWorkflow(ctx context.Context, id string, workflow *client.WorkflowAPI) (*client.WorkflowAPI, error)
+}
+
+// withWorkflowDisabled temporarily disables an enabled workflow, runs fn, then
+// restores the workflow to the enabled state using the same PUT mechanism the
+// workflow resource's Delete uses. This is required because the ISC API rejects
+// PATCH operations on enabled workflows.
+//
+// The re-enable always runs — even when fn returns an error — to avoid leaving a
+// user-enabled workflow in a disabled state after a failed apply. It fetches the
+// current workflow state before re-enabling so it does not overwrite changes
+// (e.g. a trigger patch) that fn may have applied.
+//
+// Returns fnErr (from fn) and reEnableErr (from re-enable) separately so callers
+// can surface both in diagnostics. When the workflow is already disabled the
+// disable/re-enable cycle is skipped entirely (no extra API calls).
+func withWorkflowDisabled(ctx context.Context, mgr workflowStateManager, workflowID string, fn func() error) (fnErr, reEnableErr error) {
+	workflow, err := mgr.GetWorkflow(ctx, workflowID)
+	if err != nil {
+		fnErr = fmt.Errorf("could not read workflow %q before trigger mutation: %w", workflowID, err)
+		return
+	}
+
+	wasEnabled := workflow.Enabled != nil && *workflow.Enabled
+	if !wasEnabled {
+		fnErr = fn()
+		return
+	}
+
+	// Disable the workflow before the trigger mutation.
+	tflog.Info(ctx, "Workflow is enabled, disabling before trigger mutation", map[string]any{
+		"workflow_id": workflowID,
+	})
+	disabledWorkflow := *workflow
+	falseVal := false
+	disabledWorkflow.Enabled = &falseVal
+	if _, disableErr := mgr.UpdateWorkflow(ctx, workflowID, &disabledWorkflow); disableErr != nil {
+		fnErr = fmt.Errorf("could not disable workflow %q before trigger mutation: %w", workflowID, disableErr)
+		return
+	}
+
+	// Re-enable after fn runs, even when fn fails. Fetch the latest workflow state
+	// first so we don't overwrite changes (e.g. a new trigger) that fn may have applied.
+	defer func() {
+		tflog.Info(ctx, "Re-enabling workflow after trigger mutation", map[string]any{
+			"workflow_id": workflowID,
+		})
+		current, getErr := mgr.GetWorkflow(ctx, workflowID)
+		if getErr != nil {
+			reEnableErr = fmt.Errorf("could not read workflow %q for re-enable: %w", workflowID, getErr)
+			return
+		}
+		trueVal := true
+		current.Enabled = &trueVal
+		if _, updateErr := mgr.UpdateWorkflow(ctx, workflowID, current); updateErr != nil {
+			reEnableErr = fmt.Errorf("could not re-enable workflow %q after trigger mutation: %w", workflowID, updateErr)
+		}
+	}()
+
+	fnErr = fn()
+	return
+}

--- a/internal/services/workflow_trigger/workflow_trigger_disable_test.go
+++ b/internal/services/workflow_trigger/workflow_trigger_disable_test.go
@@ -1,0 +1,137 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow_trigger
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+)
+
+// mockWorkflowStateManager implements workflowStateManager for testing.
+type mockWorkflowStateManager struct {
+	// current mirrors server-side workflow state; UpdateWorkflow mutates it.
+	current     client.WorkflowAPI
+	getCalls    int
+	updateCalls []client.WorkflowAPI // snapshot of each workflow passed to UpdateWorkflow
+	getErr      error                // returned by every GetWorkflow call when non-nil
+	updateErrOn int                  // if > 0, return updateErr on this UpdateWorkflow call number (1-based)
+	updateErr   error
+}
+
+func (m *mockWorkflowStateManager) GetWorkflow(_ context.Context, _ string) (*client.WorkflowAPI, error) {
+	m.getCalls++
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	copy := m.current
+	return &copy, nil
+}
+
+func (m *mockWorkflowStateManager) UpdateWorkflow(_ context.Context, _ string, workflow *client.WorkflowAPI) (*client.WorkflowAPI, error) {
+	m.updateCalls = append(m.updateCalls, *workflow)
+	n := len(m.updateCalls)
+	if m.updateErrOn > 0 && n == m.updateErrOn {
+		return nil, m.updateErr
+	}
+	// Mirror the enabled field into current so subsequent GetWorkflow calls see it.
+	if workflow.Enabled != nil {
+		enabled := *workflow.Enabled
+		m.current.Enabled = &enabled
+	}
+	copy := m.current
+	return &copy, nil
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestWithWorkflowDisabled_EnabledWorkflow verifies that an enabled workflow is
+// disabled before fn runs and re-enabled afterwards.
+func TestWithWorkflowDisabled_EnabledWorkflow(t *testing.T) {
+	t.Parallel()
+	mgr := &mockWorkflowStateManager{current: client.WorkflowAPI{ID: "wf1", Enabled: boolPtr(true)}}
+
+	var fnCalledWhileDisabled bool
+	fnErr, reEnableErr := withWorkflowDisabled(context.Background(), mgr, "wf1", func() error {
+		fnCalledWhileDisabled = mgr.current.Enabled == nil || !*mgr.current.Enabled
+		return nil
+	})
+
+	if fnErr != nil {
+		t.Errorf("unexpected fnErr: %v", fnErr)
+	}
+	if reEnableErr != nil {
+		t.Errorf("unexpected reEnableErr: %v", reEnableErr)
+	}
+	if !fnCalledWhileDisabled {
+		t.Error("fn should have been called while the workflow was disabled")
+	}
+	// Expect exactly 2 UpdateWorkflow calls: disable then re-enable.
+	if len(mgr.updateCalls) != 2 {
+		t.Fatalf("expected 2 UpdateWorkflow calls, got %d", len(mgr.updateCalls))
+	}
+	if mgr.updateCalls[0].Enabled == nil || *mgr.updateCalls[0].Enabled {
+		t.Error("first UpdateWorkflow call should disable the workflow (Enabled=false)")
+	}
+	if mgr.updateCalls[1].Enabled == nil || !*mgr.updateCalls[1].Enabled {
+		t.Error("second UpdateWorkflow call should re-enable the workflow (Enabled=true)")
+	}
+	if mgr.current.Enabled == nil || !*mgr.current.Enabled {
+		t.Error("workflow should be enabled after withWorkflowDisabled completes")
+	}
+}
+
+// TestWithWorkflowDisabled_DisabledWorkflow_NoExtraCalls verifies that a
+// disabled workflow is not touched — fn runs directly with no disable/re-enable.
+func TestWithWorkflowDisabled_DisabledWorkflow_NoExtraCalls(t *testing.T) {
+	t.Parallel()
+	mgr := &mockWorkflowStateManager{current: client.WorkflowAPI{ID: "wf1", Enabled: boolPtr(false)}}
+
+	fnCalled := false
+	fnErr, reEnableErr := withWorkflowDisabled(context.Background(), mgr, "wf1", func() error {
+		fnCalled = true
+		return nil
+	})
+
+	if !fnCalled {
+		t.Error("fn should have been called")
+	}
+	if fnErr != nil {
+		t.Errorf("unexpected fnErr: %v", fnErr)
+	}
+	if reEnableErr != nil {
+		t.Errorf("unexpected reEnableErr: %v", reEnableErr)
+	}
+	if len(mgr.updateCalls) != 0 {
+		t.Errorf("expected 0 UpdateWorkflow calls for a disabled workflow, got %d", len(mgr.updateCalls))
+	}
+}
+
+// TestWithWorkflowDisabled_FnError_StillReEnables verifies that re-enable runs
+// even when fn returns an error, leaving the workflow enabled as the user intended.
+func TestWithWorkflowDisabled_FnError_StillReEnables(t *testing.T) {
+	t.Parallel()
+	mgr := &mockWorkflowStateManager{current: client.WorkflowAPI{ID: "wf1", Enabled: boolPtr(true)}}
+
+	patchErr := errors.New("trigger patch failed")
+	fnErr, reEnableErr := withWorkflowDisabled(context.Background(), mgr, "wf1", func() error {
+		return patchErr
+	})
+
+	if !errors.Is(fnErr, patchErr) {
+		t.Errorf("expected fnErr == patchErr, got: %v", fnErr)
+	}
+	if reEnableErr != nil {
+		t.Errorf("unexpected reEnableErr: %v", reEnableErr)
+	}
+	// Must have 2 UpdateWorkflow calls: disable + re-enable (even after fn error).
+	if len(mgr.updateCalls) != 2 {
+		t.Fatalf("expected 2 UpdateWorkflow calls even after fn error, got %d", len(mgr.updateCalls))
+	}
+	if mgr.current.Enabled == nil || !*mgr.current.Enabled {
+		t.Error("workflow should be re-enabled even when fn fails")
+	}
+}

--- a/internal/services/workflow_trigger/workflow_trigger_disable_test.go
+++ b/internal/services/workflow_trigger/workflow_trigger_disable_test.go
@@ -27,8 +27,8 @@ func (m *mockWorkflowStateManager) GetWorkflow(_ context.Context, _ string) (*cl
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
-	copy := m.current
-	return &copy, nil
+	wfCopy := m.current
+	return &wfCopy, nil
 }
 
 func (m *mockWorkflowStateManager) UpdateWorkflow(_ context.Context, _ string, workflow *client.WorkflowAPI) (*client.WorkflowAPI, error) {
@@ -42,8 +42,8 @@ func (m *mockWorkflowStateManager) UpdateWorkflow(_ context.Context, _ string, w
 		enabled := *workflow.Enabled
 		m.current.Enabled = &enabled
 	}
-	copy := m.current
-	return &copy, nil
+	wfCopy := m.current
+	return &wfCopy, nil
 }
 
 func boolPtr(b bool) *bool { return &b }

--- a/internal/services/workflow_trigger/workflow_trigger_resource.go
+++ b/internal/services/workflow_trigger/workflow_trigger_resource.go
@@ -86,7 +86,6 @@ func (r *workflowTriggerResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	// Convert Terraform model to API model
 	workflowID := plan.WorkflowID.ValueString()
 	tflog.Debug(ctx, "Mapping workflow trigger resource model to API request", map[string]any{
 		"workflow_id":  workflowID,
@@ -98,20 +97,32 @@ func (r *workflowTriggerResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	// Set the trigger on the workflow
-	tflog.Debug(ctx, "Setting workflow trigger via SailPoint API", map[string]any{
-		"workflow_id":  workflowID,
-		"trigger_type": plan.Type.ValueString(),
+	// The ISC API rejects PATCH on enabled workflows; disable → patch → re-enable.
+	var workflow *client.WorkflowAPI
+	fnErr, reEnableErr := withWorkflowDisabled(ctx, r.client, workflowID, func() error {
+		var err error
+		tflog.Debug(ctx, "Setting workflow trigger via SailPoint API", map[string]any{
+			"workflow_id":  workflowID,
+			"trigger_type": plan.Type.ValueString(),
+		})
+		workflow, err = r.client.SetWorkflowTrigger(ctx, workflowID, apiTrigger)
+		return err
 	})
-	workflow, err := r.client.SetWorkflowTrigger(ctx, workflowID, apiTrigger)
-	if err != nil {
+
+	if reEnableErr != nil {
+		resp.Diagnostics.AddError(
+			"Error Re-enabling Workflow After Trigger Create",
+			fmt.Sprintf("Could not re-enable workflow %q after setting trigger: %s", workflowID, reEnableErr.Error()),
+		)
+	}
+	if fnErr != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating Workflow Trigger",
-			fmt.Sprintf("Could not set trigger on workflow %q: %s", workflowID, err.Error()),
+			fmt.Sprintf("Could not set trigger on workflow %q: %s", workflowID, fnErr.Error()),
 		)
 		tflog.Error(ctx, "Failed to create workflow trigger", map[string]any{
 			"workflow_id": workflowID,
-			"error":       err.Error(),
+			"error":       fnErr.Error(),
 		})
 		return
 	}
@@ -124,7 +135,6 @@ func (r *workflowTriggerResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	// Convert API response back to Terraform model
 	var state workflowTriggerModel
 	tflog.Debug(ctx, "Mapping SailPoint API response to resource model", map[string]any{
 		"workflow_id": workflowID,
@@ -134,7 +144,6 @@ func (r *workflowTriggerResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	// Set the state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -156,7 +165,6 @@ func (r *workflowTriggerResource) Read(ctx context.Context, req resource.ReadReq
 
 	workflowID := state.WorkflowID.ValueString()
 
-	// Get the workflow to retrieve the trigger
 	tflog.Debug(ctx, "Fetching workflow from SailPoint", map[string]any{
 		"workflow_id": workflowID,
 	})
@@ -173,7 +181,6 @@ func (r *workflowTriggerResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	// Check if trigger exists
 	if workflow.Trigger == nil || workflow.Trigger.Type == "" {
 		tflog.Warn(ctx, "Trigger not found on workflow, removing from state", map[string]any{
 			"workflow_id": workflowID,
@@ -182,7 +189,6 @@ func (r *workflowTriggerResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	// Convert API response to Terraform model
 	tflog.Debug(ctx, "Mapping SailPoint API response to resource model", map[string]any{
 		"workflow_id": workflowID,
 	})
@@ -191,7 +197,6 @@ func (r *workflowTriggerResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	// Set the state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -211,7 +216,6 @@ func (r *workflowTriggerResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	// Convert Terraform model to API model
 	workflowID := plan.WorkflowID.ValueString()
 	tflog.Debug(ctx, "Mapping workflow trigger resource model to API request", map[string]any{
 		"workflow_id":  workflowID,
@@ -223,72 +227,32 @@ func (r *workflowTriggerResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	// The SailPoint API blocks PATCH operations on enabled workflows. Fetch the
-	// current workflow state so we can disable it before patching if needed.
-	tflog.Debug(ctx, "Fetching workflow state before trigger update", map[string]any{
-		"workflow_id": workflowID,
+	// The ISC API rejects PATCH on enabled workflows; disable → patch → re-enable.
+	var workflow *client.WorkflowAPI
+	fnErr, reEnableErr := withWorkflowDisabled(ctx, r.client, workflowID, func() error {
+		var err error
+		tflog.Debug(ctx, "Updating workflow trigger via SailPoint API", map[string]any{
+			"workflow_id":  workflowID,
+			"trigger_type": plan.Type.ValueString(),
+		})
+		workflow, err = r.client.SetWorkflowTrigger(ctx, workflowID, apiTrigger)
+		return err
 	})
-	currentWorkflow, err := r.client.GetWorkflow(ctx, workflowID)
-	if err != nil {
+
+	if reEnableErr != nil {
 		resp.Diagnostics.AddError(
-			"Error Updating Workflow Trigger",
-			fmt.Sprintf("Could not read workflow %q before updating trigger: %s", workflowID, err.Error()),
+			"Error Re-enabling Workflow After Trigger Update",
+			fmt.Sprintf("Could not re-enable workflow %q after updating trigger: %s", workflowID, reEnableErr.Error()),
 		)
-		return
 	}
-
-	wasEnabled := currentWorkflow.Enabled != nil && *currentWorkflow.Enabled
-	if wasEnabled {
-		// PATCH is blocked on enabled workflows, so we must use PUT to disable first.
-		tflog.Info(ctx, "Workflow is enabled, disabling before trigger update", map[string]any{
-			"workflow_id": workflowID,
-		})
-		disabledWorkflow := *currentWorkflow
-		falseVal := false
-		disabledWorkflow.Enabled = &falseVal
-		if _, disableErr := r.client.UpdateWorkflow(ctx, workflowID, &disabledWorkflow); disableErr != nil {
-			resp.Diagnostics.AddError(
-				"Error Updating Workflow Trigger",
-				fmt.Sprintf("Could not disable workflow %q before updating trigger: %s", workflowID, disableErr.Error()),
-			)
-			return
-		}
-		tflog.Info(ctx, "Workflow disabled, proceeding with trigger update", map[string]any{
-			"workflow_id": workflowID,
-		})
-	}
-
-	// Update the trigger on the workflow
-	tflog.Debug(ctx, "Updating workflow trigger via SailPoint API", map[string]any{
-		"workflow_id":  workflowID,
-		"trigger_type": plan.Type.ValueString(),
-	})
-	workflow, patchErr := r.client.SetWorkflowTrigger(ctx, workflowID, apiTrigger)
-
-	// Re-enable the workflow if it was enabled before, regardless of whether the
-	// trigger patch succeeded. This avoids leaving the workflow in an unexpected
-	// disabled state when the patch fails.
-	if wasEnabled {
-		tflog.Info(ctx, "Re-enabling workflow after trigger update", map[string]any{
-			"workflow_id": workflowID,
-		})
-		reEnableOps := []client.JSONPatchOperation{client.NewReplacePatch("/enabled", true)}
-		if _, reEnableErr := r.client.PatchWorkflow(ctx, workflowID, reEnableOps); reEnableErr != nil {
-			resp.Diagnostics.AddError(
-				"Error Re-enabling Workflow After Trigger Update",
-				fmt.Sprintf("Could not re-enable workflow %q after updating trigger: %s", workflowID, reEnableErr.Error()),
-			)
-		}
-	}
-
-	if patchErr != nil {
+	if fnErr != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Workflow Trigger",
-			fmt.Sprintf("Could not update trigger on workflow %q: %s", workflowID, patchErr.Error()),
+			fmt.Sprintf("Could not update trigger on workflow %q: %s", workflowID, fnErr.Error()),
 		)
 		tflog.Error(ctx, "Failed to update workflow trigger", map[string]any{
 			"workflow_id": workflowID,
-			"error":       patchErr.Error(),
+			"error":       fnErr.Error(),
 		})
 		return
 	}
@@ -301,7 +265,6 @@ func (r *workflowTriggerResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	// Convert API response back to Terraform model
 	var state workflowTriggerModel
 	tflog.Debug(ctx, "Mapping SailPoint API response to resource model", map[string]any{
 		"workflow_id": workflowID,
@@ -311,7 +274,6 @@ func (r *workflowTriggerResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	// Set the state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -333,21 +295,30 @@ func (r *workflowTriggerResource) Delete(ctx context.Context, req resource.Delet
 
 	workflowID := state.WorkflowID.ValueString()
 
-	tflog.Debug(ctx, "Removing workflow trigger via SailPoint API", map[string]any{
-		"workflow_id":  workflowID,
-		"trigger_type": state.Type.ValueString(),
+	// The ISC API rejects PATCH on enabled workflows; disable → patch → re-enable.
+	fnErr, reEnableErr := withWorkflowDisabled(ctx, r.client, workflowID, func() error {
+		tflog.Debug(ctx, "Removing workflow trigger via SailPoint API", map[string]any{
+			"workflow_id":  workflowID,
+			"trigger_type": state.Type.ValueString(),
+		})
+		_, err := r.client.RemoveWorkflowTrigger(ctx, workflowID)
+		return err
 	})
 
-	// Remove the trigger from the workflow (set to empty object)
-	_, err := r.client.RemoveWorkflowTrigger(ctx, workflowID)
-	if err != nil {
+	if reEnableErr != nil {
+		resp.Diagnostics.AddError(
+			"Error Re-enabling Workflow After Trigger Delete",
+			fmt.Sprintf("Could not re-enable workflow %q after removing trigger: %s", workflowID, reEnableErr.Error()),
+		)
+	}
+	if fnErr != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting Workflow Trigger",
-			fmt.Sprintf("Could not remove trigger from workflow %q: %s", workflowID, err.Error()),
+			fmt.Sprintf("Could not remove trigger from workflow %q: %s", workflowID, fnErr.Error()),
 		)
 		tflog.Error(ctx, "Failed to remove workflow trigger", map[string]any{
 			"workflow_id": workflowID,
-			"error":       err.Error(),
+			"error":       fnErr.Error(),
 		})
 		return
 	}
@@ -359,7 +330,6 @@ func (r *workflowTriggerResource) Delete(ctx context.Context, req resource.Delet
 
 // ImportState implements resource.ResourceWithImportState.
 func (r *workflowTriggerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// The import ID is the workflow_id
 	tflog.Debug(ctx, "Importing workflow trigger resource", map[string]any{
 		"workflow_id": req.ID,
 	})


### PR DESCRIPTION
ISC rejects `PATCH` on an enabled workflow (`"not allowed: failed to patch workflow because it is enabled"`), so any `sailpoint_workflow_trigger` Create/Update/Delete against an enabled workflow failed — only Update had a partial workaround.

- New `withWorkflowDisabled` helper (behind a testable `workflowStateManager` interface): fetches the workflow, **skips the whole cycle when it's already disabled** (the common case — no extra API calls), disables via PUT before the trigger mutation, then **re-enables via PUT in a `defer`** (re-fetching first so it doesn't clobber the just-applied trigger change) — the workflow is always restored even if the trigger patch errors. `fnErr` and `reEnableErr` are returned separately so the caller can tell "trigger patch failed" from "couldn't re-enable."
- All three `sailpoint_workflow_trigger` CRUD operations now route through it.
- Tests: enabled → disabled → re-enabled (exactly 2 PUTs, correct order), already-disabled (no disable/enable calls), and `fn` error still restores the enabled state.

Closes #135.
