### PR TITLE
fix(workflow): preserve user values against API null normalization (#136)

### DIFF
--- a/internal/services/workflow/workflow_description_test.go
+++ b/internal/services/workflow/workflow_description_test.go
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestStringsEmptyEquivalent covers the "" ↔ null normalization guard used to
+// keep workflow.description stable across the SailPoint API's empty→null
+// rewrite (#136).
+func TestStringsEmptyEquivalent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b types.String
+		want bool
+	}{
+		{"both null", types.StringNull(), types.StringNull(), true},
+		{"null and empty", types.StringNull(), types.StringValue(""), true},
+		{"both empty", types.StringValue(""), types.StringValue(""), true},
+		{"empty and null", types.StringValue(""), types.StringNull(), true},
+		{"value and empty", types.StringValue("hello"), types.StringValue(""), false},
+		{"value and null", types.StringValue("hello"), types.StringNull(), false},
+		{"both value", types.StringValue("hello"), types.StringValue("hello"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stringsEmptyEquivalent(tc.a, tc.b); got != tc.want {
+				t.Errorf("stringsEmptyEquivalent(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/services/workflow/workflow_resource.go
+++ b/internal/services/workflow/workflow_resource.go
@@ -362,6 +362,10 @@ func (r *workflowResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	// description is user-owned (Optional) and the API normalizes "" → null, so
+	// preserve the configured value to avoid "inconsistent result after apply". (#136)
+	state.Description = plan.Description
+
 	// Set the state
 	tflog.Debug(ctx, "Setting state for workflow resource", map[string]any{
 		"id":   state.ID.ValueString(),
@@ -435,6 +439,12 @@ func (r *workflowResource) Read(ctx context.Context, req resource.ReadRequest, r
 	resp.Diagnostics.Append(applyIgnoreJSONChanges(&state, &priorState, priorState.IgnoreJSONChanges)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// description: the API normalizes "" → null; if the API value and the prior
+	// value are both empty (null or ""), keep prior to avoid spurious drift. (#136)
+	if stringsEmptyEquivalent(state.Description, priorState.Description) {
+		state.Description = priorState.Description
 	}
 
 	// Set the state
@@ -528,6 +538,9 @@ func (r *workflowResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Preserve the configured description (see #136 note in Create).
+	newState.Description = plan.Description
 
 	// Set the state
 	tflog.Debug(ctx, "Setting state for workflow resource", map[string]any{
@@ -629,4 +642,13 @@ func (r *workflowResource) UpgradeState(_ context.Context) map[int64]resource.St
 			StateUpgrader: upgradeWorkflowStateV1ToV2,
 		},
 	}
+}
+
+// stringsEmptyEquivalent reports whether both values are "empty" — i.e. each is
+// either null or the empty string. Used to treat the SailPoint API's "" → null
+// normalization of optional string fields as a non-change (#136).
+func stringsEmptyEquivalent(a, b types.String) bool {
+	emptyA := a.IsNull() || a.ValueString() == ""
+	emptyB := b.IsNull() || b.ValueString() == ""
+	return emptyA && emptyB
 }

--- a/internal/services/workflow_trigger/workflow_trigger_attributes.go
+++ b/internal/services/workflow_trigger/workflow_trigger_attributes.go
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow_trigger
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// stripTopLevelNullKeys removes top-level keys whose value is JSON null from a
+// trigger `attributes` object. SailPoint injects null-valued keys (e.g.
+// `integrationId`) into the returned attributes that the practitioner's config
+// cannot express; left in state they cause spurious drift on refresh. Returns
+// the input unchanged when it is null/unknown, not a JSON object, or has no
+// null keys (#136).
+func stripTopLevelNullKeys(attrs jsontypes.Normalized) jsontypes.Normalized {
+	if attrs.IsNull() || attrs.IsUnknown() {
+		return attrs
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(attrs.ValueString()), &obj); err != nil {
+		// Not a JSON object (or unparseable) — leave it untouched.
+		return attrs
+	}
+
+	changed := false
+	for k, v := range obj {
+		if string(v) == "null" {
+			delete(obj, k)
+			changed = true
+		}
+	}
+	if !changed {
+		return attrs
+	}
+
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return attrs
+	}
+	return jsontypes.NewNormalizedValue(string(b))
+}

--- a/internal/services/workflow_trigger/workflow_trigger_attributes_test.go
+++ b/internal/services/workflow_trigger/workflow_trigger_attributes_test.go
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package workflow_trigger
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// TestStripTopLevelNullKeys verifies that server-injected null-valued keys are
+// removed from trigger attributes while real values (including nested nulls)
+// are preserved (#136).
+func TestStripTopLevelNullKeys(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		in    jsontypes.Normalized
+		want  string // expected ValueString(); ignored when wantNull
+		isNul bool
+	}{
+		{
+			name: "strips server-added null key",
+			in:   jsontypes.NewNormalizedValue(`{"id":"x","integrationId":null}`),
+			want: `{"id":"x"}`,
+		},
+		{
+			name: "no null keys is unchanged",
+			in:   jsontypes.NewNormalizedValue(`{"id":"x"}`),
+			want: `{"id":"x"}`,
+		},
+		{
+			name: "all null keys yields empty object",
+			in:   jsontypes.NewNormalizedValue(`{"a":null,"b":null}`),
+			want: `{}`,
+		},
+		{
+			name: "nested null is preserved (only top level stripped)",
+			in:   jsontypes.NewNormalizedValue(`{"a":{"b":null}}`),
+			want: `{"a":{"b":null}}`,
+		},
+		{
+			name:  "null value passes through",
+			in:    jsontypes.NewNormalizedNull(),
+			isNul: true,
+		},
+		{
+			name: "non-object is left untouched",
+			in:   jsontypes.NewNormalizedValue(`["x"]`),
+			want: `["x"]`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripTopLevelNullKeys(tc.in)
+			if tc.isNul {
+				if !got.IsNull() {
+					t.Fatalf("expected null, got %q", got.ValueString())
+				}
+				return
+			}
+			if got.ValueString() != tc.want {
+				t.Errorf("stripTopLevelNullKeys(%q) = %q, want %q", tc.in.ValueString(), got.ValueString(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/services/workflow_trigger/workflow_trigger_resource.go
+++ b/internal/services/workflow_trigger/workflow_trigger_resource.go
@@ -144,6 +144,13 @@ func (r *workflowTriggerResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	// attributes is user-owned; the API may inject null-valued keys (e.g.
+	// integrationId). Preserve the configured value so server-added nulls don't
+	// surface as "inconsistent result after apply". (#136)
+	if !plan.Attributes.IsNull() && !plan.Attributes.IsUnknown() {
+		state.Attributes = plan.Attributes
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -196,6 +203,10 @@ func (r *workflowTriggerResource) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Drop server-injected top-level null keys (e.g. integrationId) so a refresh
+	// of an unchanged trigger doesn't report drift. (#136)
+	state.Attributes = stripTopLevelNullKeys(state.Attributes)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -272,6 +283,11 @@ func (r *workflowTriggerResource) Update(ctx context.Context, req resource.Updat
 	resp.Diagnostics.Append(state.FromAPI(ctx, workflowID, workflow.Trigger)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Preserve the configured attributes (see #136 note in Create).
+	if !plan.Attributes.IsNull() && !plan.Attributes.IsUnknown() {
+		state.Attributes = plan.Attributes
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)


### PR DESCRIPTION
Fixes two "Provider produced inconsistent result after apply" failures with the same root cause: the provider wrote the raw API response to state, but the API normalizes empty→null / injects null keys the config can't express. Both fields are user-owned (Optional), so the fix preserves the configured value.

**`sailpoint_workflow.description`** — config `""` is stored/returned as `null`.
- Create/Update: preserve the planned description.
- Read: keep the prior value when the API value and prior are both empty (null or `""`) via `stringsEmptyEquivalent`.

**`sailpoint_workflow_trigger.attributes`** — the API injects null-valued keys (e.g. `integrationId: null`).
- Create/Update: preserve the configured `attributes`.
- Read: drop server-injected top-level null keys via `stripTopLevelNullKeys` (nested nulls and real values untouched).

Unit tests added for both helpers. `make lint` / `make generate` clean (no schema/doc change).

> Implemented by hand: the @claude action ran the task twice but its push step hit an internal "directory mismatch" error both times and never landed a branch.

Closes #136.
