### PR TITLE
feat(transform): ignore_json_changes + shared internal/common/ignorejson helper

### DIFF
--- a/docs/resources/transform.md
+++ b/docs/resources/transform.md
@@ -23,6 +23,7 @@ Manages a SailPoint Transform. Transforms are used to manipulate attribute value
 ### Optional
 
 - `attributes` (String) A JSON object containing the transform-specific configuration attributes.
+- `ignore_json_changes` (List of String) Paths inside the JSON `attributes` whose drift to ignore — analogous to `lifecycle.ignore_changes`, but reaching inside the JSON string. Each entry has the form `attributes.<json-path>` (e.g. `attributes.requiresPeriodicRefresh`). The provider keeps the configured value at those paths so server-side drift there never surfaces.
 
 ### Read-Only
 

--- a/internal/common/ignorejson/ignorejson.go
+++ b/internal/common/ignorejson/ignorejson.go
@@ -1,0 +1,108 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package ignorejson implements the practitioner-driven `ignore_json_changes`
+// feature for resources with one or more JSON-string attributes. Each entry in
+// the list is a resource-rooted path of the form `<field>.<json-path>` or
+// `<field>[i].<json-path>`, where `<field>` is a JSON attribute on the resource
+// and the remainder is a minimal jsonpath (see internal/common/jsonpath) into
+// that field's parsed JSON. At apply time the practitioner's value is preserved
+// at those paths so server-side drift never surfaces.
+package ignorejson
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/jsonpath"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// fieldRemainder reports whether path p targets the JSON field `field` and, if
+// so, returns the jsonpath remainder (already prefixed with "$"). A path targets
+// a field when it is the field name followed by "." (object descent) or "["
+// (array index/wildcard).
+func fieldRemainder(p, field string) (jsonPath string, ok bool) {
+	if strings.HasPrefix(p, field+".") || strings.HasPrefix(p, field+"[") {
+		return "$" + p[len(field):], true
+	}
+	return "", false
+}
+
+// elements extracts the path list from the Terraform value, treating
+// null/unknown as empty.
+func elements(ctx context.Context, ignoreList types.List) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if ignoreList.IsNull() || ignoreList.IsUnknown() {
+		return nil, diags
+	}
+	var paths []string
+	diags.Append(ignoreList.ElementsAs(ctx, &paths, false)...)
+	return paths, diags
+}
+
+// ApplyToField re-injects sourceField's values into newField at every
+// ignore_json_changes path that targets fieldName, and returns the reconciled
+// field. It is a no-op when either value is null/unknown or no path matches.
+func ApplyToField(ctx context.Context, newField, sourceField jsontypes.Normalized, fieldName string, ignoreList types.List) (jsontypes.Normalized, diag.Diagnostics) {
+	paths, diags := elements(ctx, ignoreList)
+	if diags.HasError() || len(paths) == 0 {
+		return newField, diags
+	}
+	if newField.IsNull() || newField.IsUnknown() || sourceField.IsNull() || sourceField.IsUnknown() {
+		return newField, diags
+	}
+
+	var jsonPaths []string
+	for _, p := range paths {
+		if jp, ok := fieldRemainder(p, fieldName); ok {
+			jsonPaths = append(jsonPaths, jp)
+		}
+	}
+	if len(jsonPaths) == 0 {
+		return newField, diags
+	}
+
+	merged, err := jsonpath.PreservePathsInJSON(newField.ValueString(), sourceField.ValueString(), jsonPaths)
+	if err != nil {
+		diags.AddError("Error applying ignore_json_changes", err.Error())
+		return newField, diags
+	}
+	return jsontypes.NewNormalizedValue(merged), diags
+}
+
+// ValidatePaths checks that every ignore_json_changes entry targets one of the
+// resource's JSON fields and has a parseable jsonpath remainder.
+func ValidatePaths(ctx context.Context, ignoreList types.List, jsonFields []string) diag.Diagnostics {
+	paths, diags := elements(ctx, ignoreList)
+	if diags.HasError() {
+		return diags
+	}
+	for _, p := range paths {
+		matched := false
+		for _, field := range jsonFields {
+			jp, ok := fieldRemainder(p, field)
+			if !ok {
+				continue
+			}
+			matched = true
+			if err := jsonpath.Validate(jp); err != nil {
+				diags.AddError(
+					"Invalid ignore_json_changes path",
+					fmt.Sprintf("path %q: %s", p, err.Error()),
+				)
+			}
+			break
+		}
+		if !matched {
+			diags.AddError(
+				"Invalid ignore_json_changes path",
+				fmt.Sprintf("path %q must target one of the JSON fields %v followed by '.' or '['", p, jsonFields),
+			)
+		}
+	}
+	return diags
+}

--- a/internal/common/ignorejson/ignorejson_test.go
+++ b/internal/common/ignorejson/ignorejson_test.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package ignorejson
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func mustList(t *testing.T, vals ...string) types.List {
+	t.Helper()
+	l, diags := types.ListValueFrom(context.Background(), types.StringType, vals)
+	if diags.HasError() {
+		t.Fatalf("building list: %v", diags)
+	}
+	return l
+}
+
+func TestApplyToField(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("preserves source value at matching path", func(t *testing.T) {
+		newF := jsontypes.NewNormalizedValue(`{"refID":"server-minted","x":1}`)
+		srcF := jsontypes.NewNormalizedValue(`{"refID":"user","x":1}`)
+		got, diags := ApplyToField(ctx, newF, srcF, "attributes", mustList(t, "attributes.refID"))
+		if diags.HasError() {
+			t.Fatalf("diags: %v", diags)
+		}
+		if got.ValueString() != `{"refID":"user","x":1}` {
+			t.Errorf("got %q", got.ValueString())
+		}
+	})
+
+	t.Run("no matching field is a no-op", func(t *testing.T) {
+		newF := jsontypes.NewNormalizedValue(`{"refID":"server"}`)
+		srcF := jsontypes.NewNormalizedValue(`{"refID":"user"}`)
+		got, _ := ApplyToField(ctx, newF, srcF, "attributes", mustList(t, "properties.refID"))
+		if got.ValueString() != `{"refID":"server"}` {
+			t.Errorf("expected unchanged, got %q", got.ValueString())
+		}
+	})
+
+	t.Run("null list is a no-op", func(t *testing.T) {
+		newF := jsontypes.NewNormalizedValue(`{"a":1}`)
+		got, _ := ApplyToField(ctx, newF, newF, "attributes", types.ListNull(types.StringType))
+		if got.ValueString() != `{"a":1}` {
+			t.Errorf("expected unchanged, got %q", got.ValueString())
+		}
+	})
+
+	t.Run("null field is a no-op", func(t *testing.T) {
+		newF := jsontypes.NewNormalizedNull()
+		srcF := jsontypes.NewNormalizedValue(`{"a":1}`)
+		got, _ := ApplyToField(ctx, newF, srcF, "attributes", mustList(t, "attributes.a"))
+		if !got.IsNull() {
+			t.Errorf("expected null, got %q", got.ValueString())
+		}
+	})
+}
+
+func TestValidatePaths(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		paths   []string
+		fields  []string
+		wantErr bool
+	}{
+		{"object path ok", []string{"attributes.param_oauth.refID"}, []string{"attributes"}, false},
+		{"array path ok", []string{"form_elements[*].id"}, []string{"form_elements"}, false},
+		{"wrong field", []string{"other.foo"}, []string{"attributes"}, true},
+		{"trailing dot is invalid jsonpath", []string{"attributes."}, []string{"attributes"}, true},
+		{"bare field with no subpath", []string{"attributes"}, []string{"attributes"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := ValidatePaths(ctx, mustList(t, tc.paths...), tc.fields)
+			if diags.HasError() != tc.wantErr {
+				t.Errorf("ValidatePaths(%v) hasErr=%v want %v: %v", tc.paths, diags.HasError(), tc.wantErr, diags)
+			}
+		})
+	}
+}

--- a/internal/services/transform/transform_model.go
+++ b/internal/services/transform/transform_model.go
@@ -15,10 +15,11 @@ import (
 
 // transformModel represents the Terraform state for a SailPoint transform.
 type transformModel struct {
-	ID         types.String         `tfsdk:"id"`
-	Name       types.String         `tfsdk:"name"`
-	Type       types.String         `tfsdk:"type"`
-	Attributes jsontypes.Normalized `tfsdk:"attributes"`
+	ID                types.String         `tfsdk:"id"`
+	Name              types.String         `tfsdk:"name"`
+	Type              types.String         `tfsdk:"type"`
+	Attributes        jsontypes.Normalized `tfsdk:"attributes"`
+	IgnoreJSONChanges types.List           `tfsdk:"ignore_json_changes"`
 }
 
 // FromAPI maps fields from the API response to the Terraform model.

--- a/internal/services/transform/transform_resource.go
+++ b/internal/services/transform/transform_resource.go
@@ -10,19 +10,22 @@ import (
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common/ignorejson"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
-	_ resource.Resource                = &transformResource{}
-	_ resource.ResourceWithConfigure   = &transformResource{}
-	_ resource.ResourceWithImportState = &transformResource{}
+	_ resource.Resource                   = &transformResource{}
+	_ resource.ResourceWithConfigure      = &transformResource{}
+	_ resource.ResourceWithImportState    = &transformResource{}
+	_ resource.ResourceWithValidateConfig = &transformResource{}
 )
 
 type transformResource struct {
@@ -81,8 +84,26 @@ func (r *transformResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed:            true,
 				CustomType:          jsontypes.NormalizedType{},
 			},
+			"ignore_json_changes": schema.ListAttribute{
+				MarkdownDescription: "Paths inside the JSON `attributes` whose drift to ignore — analogous to " +
+					"`lifecycle.ignore_changes`, but reaching inside the JSON string. Each entry has the form " +
+					"`attributes.<json-path>` (e.g. `attributes.requiresPeriodicRefresh`). The provider keeps the " +
+					"configured value at those paths so server-side drift there never surfaces.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 		},
 	}
+}
+
+// ValidateConfig implements resource.ResourceWithValidateConfig.
+func (r *transformResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config transformModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(ignorejson.ValidatePaths(ctx, config.IgnoreJSONChanges, []string{"attributes"})...)
 }
 
 // Create implements resource.Resource.
@@ -141,6 +162,16 @@ func (r *transformResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Carry ignore_json_changes from plan and keep the configured value at those
+	// paths so server-side drift never surfaces. (#142)
+	state.IgnoreJSONChanges = plan.IgnoreJSONChanges
+	attrs, applyDiags := ignorejson.ApplyToField(ctx, state.Attributes, plan.Attributes, "attributes", plan.IgnoreJSONChanges)
+	resp.Diagnostics.Append(applyDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Attributes = attrs
 
 	// Set the state
 	tflog.Debug(ctx, "Setting state for transform resource", map[string]any{
@@ -203,10 +234,22 @@ func (r *transformResource) Read(ctx context.Context, req resource.ReadRequest, 
 	tflog.Debug(ctx, "Mapping SailPoint Transform API response to resource model", map[string]any{
 		"id": state.ID.ValueString(),
 	})
+	priorAttributes := state.Attributes
+	priorIgnore := state.IgnoreJSONChanges
 	resp.Diagnostics.Append(state.FromAPI(ctx, *transformResponse)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Keep prior values at ignore_json_changes paths so server drift on refresh
+	// doesn't surface. (#142)
+	state.IgnoreJSONChanges = priorIgnore
+	attrs, applyDiags := ignorejson.ApplyToField(ctx, state.Attributes, priorAttributes, "attributes", priorIgnore)
+	resp.Diagnostics.Append(applyDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Attributes = attrs
 
 	// Set the state
 	tflog.Debug(ctx, "Setting state for transform resource", map[string]any{
@@ -283,6 +326,16 @@ func (r *transformResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Carry ignore_json_changes from plan; keep prior-state values at those paths
+	// so server drift never surfaces. (#142)
+	newState.IgnoreJSONChanges = plan.IgnoreJSONChanges
+	attrs, applyDiags := ignorejson.ApplyToField(ctx, newState.Attributes, state.Attributes, "attributes", plan.IgnoreJSONChanges)
+	resp.Diagnostics.Append(applyDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	newState.Attributes = attrs
 
 	// Set the state
 	tflog.Debug(ctx, "Setting state for transform resource", map[string]any{


### PR DESCRIPTION
First consumer of the provider-wide `ignore_json_changes` rollout (#142), plus the reusable helper the remaining resources will share.

**`internal/common/ignorejson`** (new) — built on `jsonpath.PreservePathsInJSON` (#145):
- `ApplyToField(ctx, newField, sourceField, fieldName, ignoreList)` — re-injects the source value at every path targeting `fieldName`, returning the reconciled JSON field. Handles both object (`attributes.foo`) and array (`form_elements[*].foo`) field prefixes, so the next resources reuse it with one line each.
- `ValidatePaths(ctx, ignoreList, jsonFields)` — rejects paths not targeting a declared JSON field or with an invalid jsonpath remainder.
- Unit-tested (apply + validate, object & array paths, no-op cases).

**`sailpoint_transform`** — new optional `ignore_json_changes` list. Paths look like `attributes.<json-path>`. The configured value is kept at those paths (Create from plan, Read/Update from prior state) so server-side drift there never surfaces. `ValidateConfig` enforces the `attributes.`-prefixed form. Docs regenerated.

> Implemented by hand — the @claude action ran the task but its push step hit the same internal "directory mismatch" error that blocked #136, so no branch landed.

Scope notes for the rest of the rollout: **source is excluded** (it already has `ignore_attributes_paths`); **identity_profile** / **identity_attribute** are quick follow-ups reusing this helper; **form_definition** (`form_elements` is a JSON *array*) needs a small `PreservePathsInJSON` enhancement to accept top-level arrays and will come last.

Refs #142.
