### PR TITLE
docs(changelog): set 3.0.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - Unreleased
+## [3.0.0] - 2026-06-10
 
 ### Changed
 


### PR DESCRIPTION
Stamps the `[3.0.0]` changelog entry with the release date ahead of cutting the `v3.0.0` tag. Changelog-only.