### PR TITLE
chore: allow git push in @claude Action allowed-tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,9 +43,11 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Allow Claude to open/update the PR itself (with pull-requests: write above),
-          # so a tagged issue lands as a ready PR instead of a "Create PR" link.
-          claude_args: '--allowed-tools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*)"'
+          # Allow Claude to push its work branch and open/update the PR itself (with
+          # contents:write + pull-requests:write above), so a tagged issue lands as a
+          # ready PR. Without Bash(git push:*) the work is committed only inside the
+          # ephemeral runner and is lost when the job ends.
+          claude_args: '--allowed-tools "Bash(git push:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr view:*)"'
 
       # Deterministic fallback: if Claude pushed a claude/issue-<n>-* branch but did not
       # open a PR itself (model-dependent — it sometimes leaves only a "Create PR" link),


### PR DESCRIPTION
## Why

#154 gave the `@claude` Action write perms + `gh pr create`, but the `claude_args` allow-list omitted `Bash(git push:*)`. On the first delegated run (#91) the Action implemented the full feature correctly and committed it locally on `claude/issue-91-*`, but **the `git push` was blocked** — so the branch never left the ephemeral runner and was lost when the job ended. The fallback step then found no branch to PR.

## What

Add `Bash(git push:*)` to the front of the `--allowed-tools` list. This is exactly the fix the Action itself diagnosed and attempted (as a second commit) before it was lost.

## After merge

Re-fire `@claude` on #91 — the implementation will re-run and this time the branch will reach origin, so the Action (or the fallback step) opens the PR.