### PR TITLE
chore: prepare v3.1.0 release notes

### DIFF
--- a/.github/RELEASE_NOTES_v3.1.0.md
+++ b/.github/RELEASE_NOTES_v3.1.0.md
@@ -1,0 +1,75 @@
+# Release v3.1.0 - Source Attribute Synchronization
+
+Adds Terraform management of SailPoint ISC **attribute synchronization** — both the persistent configuration (which identity attributes sync to a source's accounts) and an action to trigger a sync on demand. This closes a common out-of-Terraform gap for sources that must keep account attributes (e.g. Active Directory `accountExpires`) in lockstep with identity data after the initial create.
+
+## What's New
+
+### `sailpoint_source_attribute_sync_config` (resource + data source)
+
+Manages the per-attribute `enabled` flags that decide which identity attributes ISC pushes to a source's accounts.
+
+- **Adopt-only lifecycle** — the config always exists for a source. Create reads the current config and applies your declared `enabled` flags via PUT; Update sends a full PUT; Delete removes the resource from Terraform state only (the config persists in ISC).
+- **Partial management** — attributes you don't list keep their current server value, so you can manage a subset without accidentally disabling the rest.
+- **Importable** by source ID (`terraform import sailpoint_source_attribute_sync_config.ad <source-id>`); the data source exposes the full syncable attribute list.
+- Backed by the Beta `/beta/sources/{id}/attribute-sync-config` API. Requires `ORG_ADMIN`.
+
+> An attribute is only syncable once its field exists in the source's Create Account provisioning policy — the candidate list (`target`) is derived from that policy.
+
+**Example:**
+
+```hcl
+resource "sailpoint_source_attribute_sync_config" "ad" {
+  source_id = sailpoint_source.ad.id
+
+  attributes = [
+    { name = "email",      enabled = true },
+    { name = "department", enabled = true },
+    { name = "firstname",  enabled = false },
+  ]
+}
+```
+
+### `sailpoint_sync_source_attributes` (action)
+
+Triggers a one-time attribute sync for a source — the provider's first Terraform Provider Action.
+
+- Run standalone, or wire it to a resource's `lifecycle.action_trigger` to resync automatically after the sync config changes.
+- Requires **Terraform >= 1.14** and `ORG_ADMIN`. Propagation is asynchronous — the action returns once the sync is triggered (`POST /v2025/sources/{id}/synchronize-attributes`, experimental).
+
+**Example (auto-resync after a config change):**
+
+```hcl
+resource "sailpoint_source_attribute_sync_config" "ad" {
+  source_id = sailpoint_source.ad.id
+
+  attributes = [
+    { name = "email",      enabled = true },
+    { name = "department", enabled = true },
+  ]
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create, after_update]
+      actions = [action.sailpoint_sync_source_attributes.auto.trigger]
+    }
+  }
+}
+
+action "sailpoint_sync_source_attributes" "auto" {
+  config {
+    source_id = sailpoint_source.ad.id
+  }
+}
+```
+
+## Notes
+
+- This is the provider's first **Beta-API** resource and first **Provider Action** — the provider now implements `provider.ProviderWithActions`.
+
+## Full Changelog
+
+See [CHANGELOG.md](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/blob/main/CHANGELOG.md) for complete details.
+
+---
+
+**Questions or Issues?** Please open an issue on [GitHub](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-06-10
+
+### Added
+
+- **Source Attribute Synchronization** — new `sailpoint_source_attribute_sync_config` resource and data source, plus the `sailpoint_sync_source_attributes` provider action. (#91)
+  - **`sailpoint_source_attribute_sync_config`** (resource + data source): manages which identity attributes are synced to a source's accounts (the per-attribute `enabled` flags). Adopt-only lifecycle — Create reads the existing config and applies declared `enabled` flags via PUT, Update sends a full PUT, and Delete is a no-op (the config always exists for a source). Partial management is supported: attributes you don't list keep their current server value, so a subset can be managed without disabling the rest. Importable by source ID. Backed by the Beta `/beta/sources/{id}/attribute-sync-config` API; requires `ORG_ADMIN`.
+  - **`sailpoint_sync_source_attributes`** (action): triggers a one-time attribute sync for a source (`POST /v2025/sources/{id}/synchronize-attributes`, experimental). Usable standalone or as a lifecycle `action_trigger` to resync automatically after the sync config changes. Requires Terraform >= 1.14 and `ORG_ADMIN`; propagation is asynchronous.
+  - First provider Action and first Beta-API resource — the provider now implements `provider.ProviderWithActions`.
+
 ## [3.0.0] - 2026-06-10
 
 ### Changed
@@ -573,6 +582,7 @@ This release ensures all documentation and examples match the actual provider ca
 
 ---
 
+[3.1.0]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v3.0.0...v3.1.0
 [2.3.3]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v2.1.1...v2.3.1


### PR DESCRIPTION
## v3.1.0 — Source Attribute Synchronization

Prep for the **v3.1.0** release. Minor bump (additive, no breaking changes).

Since v3.0.0 the only user-facing change is the #91 feature: `sailpoint_source_attribute_sync_config` (resource + data source) and the `sailpoint_sync_source_attributes` action. The other commits on `main` (CI `@claude` perms, CLAUDE.md refresh) are internal and intentionally omitted from the release notes.

### Changes in this PR
- `CHANGELOG.md` — `[3.1.0]` entry + comparison link.
- `.github/RELEASE_NOTES_v3.1.0.md` — GitHub release notes.

### How the release happens (after merge)
This PR only stages the notes. The release is cut by tagging **`v3.1.0`** on `main`, which triggers `release.yml` (goreleaser → GitHub release → Terraform Registry). That tag/publish step is intentionally **not** part of this PR — it's the irreversible, outward-facing step and awaits explicit go-ahead.