### PR TITLE
chore: prepare v3.2.0 release notes

### DIFF
--- a/.github/RELEASE_NOTES_v3.2.0.md
+++ b/.github/RELEASE_NOTES_v3.2.0.md
@@ -1,0 +1,60 @@
+# Release v3.2.0 - Source `ignore_json_changes`
+
+Brings `sailpoint_source` in line with `transform` and `workflow`: nested fields inside `connector_attributes` can now be ignored with the provider-wide `ignore_json_changes` list. This fixes a permanent phantom diff on sources that declare a top-level key containing a server-masked secret (e.g. a `password` nested in `domainSettings`), which previously left the resource stuck at `1 to change` forever.
+
+## What's New
+
+### `sailpoint_source.ignore_json_changes`
+
+A resource-level list of paths inside the JSON `connector_attributes` whose drift the provider should ignore — analogous to `lifecycle.ignore_changes`, but reaching *inside* the JSON string. Consistent with the same attribute on `transform` and `workflow`.
+
+- Each entry has the form `connector_attributes.<json-path>`, e.g. `connector_attributes.domainSettings[*].password`.
+- A declared path is **fully ignored in plan and apply**: a server-managed or masked nested field you declare here is absent from the managed `connector_attributes` (so it never produces a phantom diff), and its server value is never overwritten on apply.
+- Drift on **non-ignored sibling fields** (e.g. `domainDN`, `servers`, `user`) is still surfaced.
+- Supported syntax: `connector_attributes.key`, `connector_attributes.key.nested`, `connector_attributes.key[N].field`, `connector_attributes.key[*].field`.
+
+**Example:**
+
+```hcl
+resource "sailpoint_source" "ad" {
+  name      = "Corporate AD"
+  connector = "active-directory"
+
+  owner = {
+    type = "IDENTITY"
+    id   = sailpoint_identity.svc.id
+  }
+
+  connector_attributes = jsonencode({
+    domainSettings = [{
+      domainDN = "DC=example,DC=com"
+      servers  = ["192.0.2.10", "192.0.2.11"]
+      user     = "svc-bind@example.com"
+      # password omitted — set out-of-band, masked by the API
+    }]
+  })
+
+  # Fully ignore the masked nested secret: no phantom diff, never overwritten.
+  ignore_json_changes = ["connector_attributes.domainSettings[*].password"]
+}
+```
+
+## Fixed
+
+- **Phantom diff on ignored nested secrets.** The previous `ignore_attributes_paths` was only consulted in the apply PATCH — never in Read or `ModifyPlan` — so a nested field the API returns masked (`"********"`) was re-projected on every read while the config omitted it, producing a permanent `1 to change` that never reached `No changes`. Ignored paths are now pruned from the projected `connector_attributes` on read, so the resource converges. (#162)
+
+## Deprecated
+
+- **`sailpoint_source.ignore_attributes_paths`** is deprecated in favour of `ignore_json_changes`. Existing configurations keep working unchanged — migrate `$.<path>` entries to `connector_attributes.<path>` at your convenience. The attribute will be removed in a future major version. (#162)
+
+## Notes
+
+- Additive, non-breaking minor release. No configuration changes are required to upgrade.
+
+## Full Changelog
+
+See [CHANGELOG.md](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/blob/main/CHANGELOG.md) for complete details.
+
+---
+
+**Questions or Issues?** Please open an issue on [GitHub](https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.0] - 2026-06-24
 
 ### Added
 
@@ -597,6 +597,7 @@ This release ensures all documentation and examples match the actual provider ca
 
 ---
 
+[3.2.0]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v3.0.0...v3.1.0
 [2.3.3]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v2.3.2...v2.3.3
 [2.3.2]: https://github.com/AnasSahel/terraform-provider-sailpoint-isc-community/compare/v2.3.1...v2.3.2


### PR DESCRIPTION
Prep for the **v3.2.0** release. Minor bump (additive, non-breaking).

Since v3.1.0 the only user-facing change is #162: `sailpoint_source` gains `ignore_json_changes` (converging on the provider-wide helper used by `transform`/`workflow`), fixing the permanent phantom diff on ignored masked nested secrets, and deprecating `ignore_attributes_paths` (kept working).

### Changes in this PR
- `CHANGELOG.md` — `[3.2.0]` entry (date + compare link).
- `.github/RELEASE_NOTES_v3.2.0.md` — GitHub release notes.

### How the release happens (after merge)
This PR only stages the notes. The release is cut by tagging **`v3.2.0`** on `main`, which triggers `release.yml` (goreleaser → GitHub release → Terraform Registry). That tag/publish step is the irreversible, outward-facing one and is done right after this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)