### PR TITLE
fix: handle array-valued identity attributes in data source

### DIFF
--- a/docs/data-sources/identity.md
+++ b/docs/data-sources/identity.md
@@ -62,7 +62,7 @@ output "identity_lifecycle_state" {
 ### Read-Only
 
 - `alias` (String) The login alias (username) of the identity.
-- `attributes` (Map of String) Additional identity attributes as key-value pairs. Keys depend on the org's identity schema.
+- `attributes` (Map of String) Additional identity attributes as key-value pairs. Keys depend on the org's identity schema. Scalar values are returned as plain strings; multi-valued or complex values are JSON-encoded strings.
 - `created` (String)
 - `email_address` (String) The email address of the identity.
 - `employee_number` (String) The employee number of the identity.

--- a/internal/client/identities.go
+++ b/internal/client/identities.go
@@ -29,7 +29,7 @@ type IdentityAPI struct {
 	IdentityProfile *ObjectRefAPI     `json:"identityProfile,omitempty"`
 	Source          *ObjectRefAPI     `json:"source,omitempty"`
 	LifecycleState  *IdentityLCSAPI   `json:"lifecycleState,omitempty"`
-	Attributes      map[string]string `json:"attributes,omitempty"`
+	Attributes      map[string]interface{} `json:"attributes,omitempty"`
 	Created         *string           `json:"created,omitempty"`
 	Modified        *string           `json:"modified,omitempty"`
 }

--- a/internal/services/identity/identity_data_source.go
+++ b/internal/services/identity/identity_data_source.go
@@ -5,7 +5,10 @@ package identity
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
 	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/common"
@@ -155,9 +158,10 @@ func (d *identityDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				},
 			},
 			"attributes": schema.MapAttribute{
-				Computed:            true,
-				ElementType:         types.StringType,
-				MarkdownDescription: "Additional identity attributes as key-value pairs. Keys depend on the org's identity schema.",
+				Computed:    true,
+				ElementType: types.StringType,
+				MarkdownDescription: "Additional identity attributes as key-value pairs. Keys depend on the org's identity schema. " +
+					"Scalar values are returned as plain strings; multi-valued or complex values are JSON-encoded strings.",
 			},
 			"created":  schema.StringAttribute{Computed: true},
 			"modified": schema.StringAttribute{Computed: true},
@@ -298,7 +302,12 @@ func populateIdentityDSModel(ctx context.Context, m *identityDSModel, api *clien
 	}
 
 	if len(api.Attributes) > 0 {
-		attrMap, diags := types.MapValueFrom(ctx, types.StringType, api.Attributes)
+		attrStrings, diags := identityAttributesToStringMap(api.Attributes)
+		diagnostics.Append(diags...)
+		if diagnostics.HasError() {
+			return diagnostics
+		}
+		attrMap, diags := types.MapValueFrom(ctx, types.StringType, attrStrings)
 		diagnostics.Append(diags...)
 		m.Attributes = attrMap
 	} else {
@@ -306,6 +315,55 @@ func populateIdentityDSModel(ctx context.Context, m *identityDSModel, api *clien
 	}
 
 	return diagnostics
+}
+
+func identityAttributesToStringMap(attrs map[string]interface{}) (map[string]string, diag.Diagnostics) {
+	if len(attrs) == 0 {
+		return nil, diag.Diagnostics{}
+	}
+
+	result := make(map[string]string, len(attrs))
+	var diagnostics diag.Diagnostics
+
+	for key, value := range attrs {
+		str, diags := identityAttributeValueToString(value)
+		diagnostics.Append(diags...)
+		if diagnostics.HasError() {
+			return nil, diagnostics
+		}
+		result[key] = str
+	}
+
+	return result, diagnostics
+}
+
+func identityAttributeValueToString(value interface{}) (string, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	if value == nil {
+		return "", diagnostics
+	}
+
+	switch val := value.(type) {
+	case string:
+		return val, diagnostics
+	case float64:
+		if val == math.Trunc(val) && !math.IsInf(val, 0) && !math.IsNaN(val) {
+			return strconv.FormatInt(int64(val), 10), diagnostics
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64), diagnostics
+	case bool:
+		return strconv.FormatBool(val), diagnostics
+	default:
+		bytes, err := json.Marshal(val)
+		if err != nil {
+			diagnostics.AddError(
+				"Error Converting Identity Attribute",
+				fmt.Sprintf("Could not serialize attribute value: %s", err.Error()),
+			)
+			return "", diagnostics
+		}
+		return string(bytes), diagnostics
+	}
 }
 
 func stringPtrToTF(s *string) types.String {

--- a/internal/services/identity/identity_data_source_test.go
+++ b/internal/services/identity/identity_data_source_test.go
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package identity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/AnasSahel/terraform-provider-sailpoint-isc-community/internal/client"
+)
+
+func TestIdentityAPI_UnmarshalMixedAttributes(t *testing.T) {
+	t.Helper()
+
+	raw := `{
+		"id": "abc123",
+		"name": "Test User",
+		"attributes": {
+			"department": "Engineering",
+			"roles": ["Admin", "User"],
+			"active": true,
+			"count": 42
+		}
+	}`
+
+	var identity client.IdentityAPI
+	if err := json.Unmarshal([]byte(raw), &identity); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if identity.ID != "abc123" {
+		t.Fatalf("expected id abc123, got %q", identity.ID)
+	}
+	if len(identity.Attributes) != 4 {
+		t.Fatalf("expected 4 attributes, got %d", len(identity.Attributes))
+	}
+
+	roles, ok := identity.Attributes["roles"].([]interface{})
+	if !ok {
+		t.Fatalf("roles attribute not an array, got %T", identity.Attributes["roles"])
+	}
+	if len(roles) != 2 {
+		t.Fatalf("expected 2 roles, got %d", len(roles))
+	}
+}
+
+func TestIdentityAttributesToStringMap(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]string
+	}{
+		{
+			name: "scalar and collection values",
+			input: map[string]interface{}{
+				"department": "Engineering",
+				"roles":      []interface{}{"Admin", "User"},
+				"active":     true,
+				"count":      float64(42),
+			},
+			expected: map[string]string{
+				"department": "Engineering",
+				"roles":      `["Admin","User"]`,
+				"active":     "true",
+				"count":      "42",
+			},
+		},
+		{
+			name:     "empty map",
+			input:    map[string]interface{}{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, diags := identityAttributesToStringMap(tt.input)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+
+			if tt.expected == nil {
+				if result != nil {
+					t.Fatalf("expected nil map, got %#v", result)
+				}
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Fatalf("expected %d attributes, got %d: %#v", len(tt.expected), len(result), result)
+			}
+
+			for key, want := range tt.expected {
+				got, ok := result[key]
+				if !ok {
+					t.Fatalf("missing key %q", key)
+				}
+				if got != want {
+					t.Fatalf("key %q: expected %q, got %q", key, want, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix sailpoint_identity data source failing when ISC API returns multi-valued or non-string identity attributes
- Accept mixed attribute types in the client and JSON-encode complex values for the Terraform map output
- Add unit tests and update data source documentation

Fixes AnasSahel/terraform-provider-sailpoint-isc-community#171

## Test plan
- [x] go test ./internal/services/identity/...
- [x] terraform plan against ISC demo tenant (data.sailpoint_identity.amanda_ross)
- [ ] make lint
- [ ] make generate